### PR TITLE
Refactor Single Item code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,9 @@
     "antecedent/patchwork": "2.1.*",
     "phpunit/phpunit": "^9.4",
     "brianium/paratest": "dev-master",
-    "10up/wp_mock": "0.4.2"
+    "10up/wp_mock": "0.4.2",
+    "dealerdirect/phpcodesniffer-composer-installer": "*",
+    "phpcompatibility/php-compatibility": "*",
+    "wp-coding-standards/wpcs": "*"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,8 @@
     "dealerdirect/phpcodesniffer-composer-installer": "*",
     "phpcompatibility/php-compatibility": "*",
     "wp-coding-standards/wpcs": "*"
+  },
+  "scripts": {
+    "phpcbf": "./vendor/bin/phpcbf --standard=WordPress"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0ec3fac43e8e969bf989d67d0bf75a3f",
+    "content-hash": "9305a8f3b1fa2fd75f7892f2138a00d9",
     "packages": [],
     "packages-dev": [
         {
@@ -194,6 +194,77 @@
                 }
             ],
             "time": "2021-11-19T07:41:55+00:00"
+        },
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "7d5cb8826ed72d4ca4c07acf005bba2282e5a7c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/7d5cb8826ed72d4ca4c07acf005bba2282e5a7c7",
+                "reference": "7d5cb8826ed72d4ca4c07acf005bba2282e5a7c7",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.3",
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "default-branch": true,
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2021-08-16T14:43:41+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -615,6 +686,68 @@
                 "source": "https://github.com/phar-io/version/tree/3.1.0"
             },
             "time": "2021-02-23T14:00:09+00:00"
+        },
+        {
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibility"
+            },
+            "time": "2019-12-27T09:44:58+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -1269,22 +1402,28 @@
         },
         {
             "name": "psr/container",
-            "version": "1.x-dev",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.4.0"
             },
+            "default-branch": true,
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Psr\\Container\\": "src/"
@@ -1311,9 +1450,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.2"
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
             },
-            "time": "2021-11-05T16:50:12+00:00"
+            "time": "2021-11-05T16:47:00+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2282,26 +2421,83 @@
             "time": "2020-09-28T06:39:44+00:00"
         },
         {
+            "name": "squizlabs/php_codesniffer",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "0ed1d8c5ac325d6222396f7034d9c8e9d68a0cc9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/0ed1d8c5ac325d6222396f7034d9c8e9d68a0cc9",
+                "reference": "0ed1d8c5ac325d6222396f7034d9c8e9d68a0cc9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "default-branch": true,
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2021-11-22T22:20:58+00:00"
+        },
+        {
             "name": "symfony/console",
             "version": "5.4.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "4c10d71a5184a4de70eb3ad9c3e38d37b5ff3947"
+                "reference": "f797eedbbede8a2e6cdb8d5f16da0d6fb9bbfd12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/4c10d71a5184a4de70eb3ad9c3e38d37b5ff3947",
-                "reference": "4c10d71a5184a4de70eb3ad9c3e38d37b5ff3947",
+                "url": "https://api.github.com/repos/symfony/console/zipball/f797eedbbede8a2e6cdb8d5f16da0d6fb9bbfd12",
+                "reference": "f797eedbbede8a2e6cdb8d5f16da0d6fb9bbfd12",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1",
+                "symfony/deprecation-contracts": "^2.1|^3",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php73": "^1.8",
                 "symfony/polyfill-php80": "^1.16",
-                "symfony/service-contracts": "^1.1|^2",
+                "symfony/service-contracts": "^1.1|^2|^3",
                 "symfony/string": "^5.1|^6.0"
             },
             "conflict": {
@@ -2378,29 +2574,30 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-22T11:33:26+00:00"
+            "time": "2021-11-23T18:53:11+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "2.5.x-dev",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "6f981ee24cf69ee7ce9736146d1c57c2780598a8"
+                "reference": "c726b64c1ccfe2896cb7df2e1331c357ad1c8ced"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/6f981ee24cf69ee7ce9736146d1c57c2780598a8",
-                "reference": "6f981ee24cf69ee7ce9736146d1c57c2780598a8",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/c726b64c1ccfe2896cb7df2e1331c357ad1c8ced",
+                "reference": "c726b64c1ccfe2896cb7df2e1331c357ad1c8ced",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=8.0.2"
             },
+            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.5-dev"
+                    "dev-main": "3.0-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -2429,7 +2626,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/main"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.0.0"
             },
             "funding": [
                 {
@@ -2445,7 +2642,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-07-12T14:48:14+00:00"
+            "time": "2021-11-01T23:48:49+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2536,12 +2733,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "5911fe42c266a5917aef12e45fbd3a640a9e3b18"
+                "reference": "81b86b50cf841a64252b439e738e97f4a34e2783"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/5911fe42c266a5917aef12e45fbd3a640a9e3b18",
-                "reference": "5911fe42c266a5917aef12e45fbd3a640a9e3b18",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/81b86b50cf841a64252b439e738e97f4a34e2783",
+                "reference": "81b86b50cf841a64252b439e738e97f4a34e2783",
                 "shasum": ""
             },
             "require": {
@@ -2610,7 +2807,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-10-26T17:12:59+00:00"
+            "time": "2021-11-23T21:10:46+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
@@ -2951,12 +3148,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "956acb321f471255cced3098e0c7e4f1444b5485"
+                "reference": "e8f02d0795d3852e2e0169dc7660786e9de30859"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/956acb321f471255cced3098e0c7e4f1444b5485",
-                "reference": "956acb321f471255cced3098e0c7e4f1444b5485",
+                "url": "https://api.github.com/repos/symfony/process/zipball/e8f02d0795d3852e2e0169dc7660786e9de30859",
+                "reference": "e8f02d0795d3852e2e0169dc7660786e9de30859",
                 "shasum": ""
             },
             "require": {
@@ -3005,26 +3202,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-17T12:18:18+00:00"
+            "time": "2021-11-23T14:18:55+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "2.5.x-dev",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "1ab11b933cd6bc5464b08e81e2c5b07dec58b0fc"
+                "reference": "36715ebf9fb9db73db0cb24263c79077c6fe8603"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/1ab11b933cd6bc5464b08e81e2c5b07dec58b0fc",
-                "reference": "1ab11b933cd6bc5464b08e81e2c5b07dec58b0fc",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/36715ebf9fb9db73db0cb24263c79077c6fe8603",
+                "reference": "36715ebf9fb9db73db0cb24263c79077c6fe8603",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "psr/container": "^1.1",
-                "symfony/deprecation-contracts": "^2.1"
+                "php": ">=8.0.2",
+                "psr/container": "^2.0"
             },
             "conflict": {
                 "ext-psr": "<1.1|>=2"
@@ -3032,10 +3228,11 @@
             "suggest": {
                 "symfony/service-implementation": ""
             },
+            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.5-dev"
+                    "dev-main": "3.0-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -3072,7 +3269,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/2.5"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.0.0"
             },
             "funding": [
                 {
@@ -3088,35 +3285,37 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-04T16:48:04+00:00"
+            "time": "2021-11-04T17:53:12+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "5.4.x-dev",
+            "version": "6.0.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "dad92b16d84cb661f39c85a5dbb6e4792b92e90f"
+                "reference": "ba727797426af0f587f4800566300bdc0cda0777"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/dad92b16d84cb661f39c85a5dbb6e4792b92e90f",
-                "reference": "dad92b16d84cb661f39c85a5dbb6e4792b92e90f",
+                "url": "https://api.github.com/repos/symfony/string/zipball/ba727797426af0f587f4800566300bdc0cda0777",
+                "reference": "ba727797426af0f587f4800566300bdc0cda0777",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
+                "php": ">=8.0.2",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-intl-grapheme": "~1.0",
                 "symfony/polyfill-intl-normalizer": "~1.0",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php80": "~1.15"
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/translation-contracts": "<2.0"
             },
             "require-dev": {
-                "symfony/error-handler": "^4.4|^5.0|^6.0",
-                "symfony/http-client": "^4.4|^5.0|^6.0",
-                "symfony/translation-contracts": "^1.1|^2",
-                "symfony/var-exporter": "^4.4|^5.0|^6.0"
+                "symfony/error-handler": "^5.4|^6.0",
+                "symfony/http-client": "^5.4|^6.0",
+                "symfony/translation-contracts": "^2.0|^3.0",
+                "symfony/var-exporter": "^5.4|^6.0"
             },
             "type": "library",
             "autoload": {
@@ -3155,7 +3354,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/5.4"
+                "source": "https://github.com/symfony/string/tree/6.0"
             },
             "funding": [
                 {
@@ -3171,7 +3370,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-10-28T19:23:26+00:00"
+            "time": "2021-10-29T07:35:21+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -3281,6 +3480,57 @@
                 "source": "https://github.com/webmozarts/assert/tree/master"
             },
             "time": "2021-06-19T13:45:26+00:00"
+        },
+        {
+            "name": "wp-coding-standards/wpcs",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.3.1"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
+                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
+                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
+            },
+            "time": "2020-05-13T23:57:56+00:00"
         }
     ],
     "aliases": [],

--- a/includes/classes/admin/ajax/handlers.php
+++ b/includes/classes/admin/ajax/handlers.php
@@ -153,7 +153,7 @@ class Handlers extends Plugin_Base {
 				'status'     => $status,
 				'itemName'   => isset( $item->name ) ? $item->name : __( 'N/A', 'gathercontent-importer' ),
 				'updated_at' => isset( $item->updated_at )
-					? Utils::relative_date( $item->updated_at->date )
+					? Utils::relative_date( $item->updated_at )
 					: __( '&mdash;', 'gathercontent-importer' ),
 				'current'    => \GatherContent\Importer\post_is_current( $post['id'], $item ),
 			);

--- a/includes/classes/admin/bulk.php
+++ b/includes/classes/admin/bulk.php
@@ -263,7 +263,7 @@ class Bulk extends Post_Base {
 			|| ! ( $status_id = $this->_post_val( 'gc_status' ) )
 			|| ! ( $item_id = absint( \GatherContent\Importer\get_post_item_id( $post_id ) ) )
 			|| ! ( $mapping_id = absint( \GatherContent\Importer\get_post_mapping_id( $post_id ) ) )
-			|| ! ( $item = $this->api->get_item( $item_id ) )
+			|| ! ( $item = $this->api->get_item( $item_id, true ) )
 			|| ( isset( $item->status_id ) && absint( $status_id ) === absint( $item->status_id ) )
 		) {
 			return;

--- a/includes/classes/api.php
+++ b/includes/classes/api.php
@@ -184,7 +184,7 @@ class API extends Base {
 	 * @link https://docs.gathercontent.com/reference/getitem
 	 *
 	 * @param  int $item_id Item ID.
-	 * @return mixed          Results of request.
+	 * @return mixed        Results of request.
 	 */
 	public function get_item( $item_id ) {
 
@@ -200,7 +200,7 @@ class API extends Base {
 
 		// append status to the item as it was removed in the V2 APIs and needed everywhere
 		if( $response->data ) {
-			$response->data->status->data 	 = (object) $this->add_status_to_item( $response );
+			$response->data->status->data 	 = (object) $this->add_status_to_item( $response->data );
 			$response->data->status_name 	 = $response->data->status->data->name ?: '';
 		}
 
@@ -212,22 +212,22 @@ class API extends Base {
 	 *
 	 * @since  3.2.0
 	 *
-	 * @param  mixed $item array of item result.
+	 * @param  mixed $item item result object.
 	 * @return mixed $status_data.
 	 */
 	public function add_status_to_item( $item ) {
 
-		if(! $item->data->project_id ) {
+		if(! $item->project_id ) {
 			return array();
 		}
 
 		// get cached version of all the project statuses by making sure that the cache is enabled for this request
 		$this->disable_cache		= false;
 		$this->reset_request_cache 	= false;
-		$all_statuses    			= $this->get_project_statuses( $item->data->project_id );
+		$all_statuses    			= $this->get_project_statuses( $item->project_id );
 
 		$matched_status  			= is_array( $all_statuses )
-			? wp_list_filter( $all_statuses, array( 'id' => $item->data->status_id ) )
+			? wp_list_filter( $all_statuses, array( 'id' => $item->status_id ) )
 			: array();
 		$status_data			 	= count( $matched_status ) > 0 ? $matched_status[0] : array();
 

--- a/includes/classes/api.php
+++ b/includes/classes/api.php
@@ -137,7 +137,7 @@ class API extends Base {
 	 * @return mixed             Results of request.
 	 */
 	public function get_project_statuses( $project_id, $response = '' ) {
-		return $this->get( 'projects/' . $project_id . '/statuses', array(), $response);
+		return $this->get( 'projects/' . $project_id . '/statuses', array(), $response );
 	}
 
 	/**
@@ -158,8 +158,8 @@ class API extends Base {
 
 		$query_params = array(
 			'template_id' => $template_id,
-			'include'	  => 'status_name',
-			'per_page'	  => 500
+			'include'     => 'status_name',
+			'per_page'    => 500,
 		);
 
 		$response = $this->get(
@@ -200,9 +200,9 @@ class API extends Base {
 		);
 
 		// append status to the item as it was removed in the V2 APIs and needed everywhere
-		if( ! $exclude_status && $response ) {
-			$response->status  		 = (object) $this->add_status_to_item( $response );
-			$response->status_name 	 = $response->status->data->name ?: '';
+		if ( ! $exclude_status && $response ) {
+			$response->status      = (object) $this->add_status_to_item( $response );
+			$response->status_name = $response->status->data->name ?: '';
 		}
 
 		return $response;
@@ -218,21 +218,21 @@ class API extends Base {
 	 */
 	public function add_status_to_item( $item ) {
 
-		if(! $item->project_id ) {
+		if ( ! $item->project_id ) {
 			return array();
 		}
 
 		// get cached version of all the project statuses by making sure that the cache is enabled for this request
-		$this->disable_cache		= false;
-		$this->reset_request_cache 	= false;
-		$all_statuses    			= $this->get_project_statuses( $item->project_id );
+		$this->disable_cache       = false;
+		$this->reset_request_cache = false;
+		$all_statuses              = $this->get_project_statuses( $item->project_id );
 
-		$matched_status  			= is_array( $all_statuses )
-			? wp_list_filter( $all_statuses, array( 'id' => $item->status_id ) )
+		$matched_status = is_array( $all_statuses )
+			? array_values( wp_list_filter( $all_statuses, array( 'id' => $item->status_id ) ) )
 			: array();
-		$data			 			= count( $matched_status ) > 0 ? $matched_status[0] : array();
+		$data           = count( $matched_status ) > 0 ? $matched_status[0] : array();
 
-		return compact('data');
+		return compact( 'data' );
 	}
 
 	/**
@@ -365,7 +365,7 @@ class API extends Base {
 	 * @return mixed              Results of request.
 	 */
 	public function get_template( $template_id, $args = array() ) {
-		$response = $this->get('templates/' . $template_id, $args, 'full_data');
+		$response = $this->get( 'templates/' . $template_id, $args, 'full_data' );
 		return $response;
 	}
 
@@ -640,14 +640,14 @@ class API extends Base {
 	 *
 	 * @see    API::cache_get() For additional information
 	 *
-	 * @param  string $endpoint 	  GatherContent API endpoint to retrieve.
-	 * @param  array  $args     	  Optional. Request arguments. Default empty array.
-	 * @param  string $response 	  Optional. expected response. Default empty
+	 * @param  string $endpoint       GatherContent API endpoint to retrieve.
+	 * @param  array  $args           Optional. Request arguments. Default empty array.
+	 * @param  string $response       Optional. expected response. Default empty
 	 * @param  array  $query_params   Optional. Request query parameters to append to the URL. Default empty array.
 	 *
 	 * @return mixed  The response.
 	 */
-	public function get( $endpoint, $args = array(), $response = '', $query_params = array() ){
+	public function get( $endpoint, $args = array(), $response = '', $query_params = array() ) {
 
 		$data = $this->cache_get( $endpoint, DAY_IN_SECONDS, $args, 'GET', $query_params );
 
@@ -669,12 +669,12 @@ class API extends Base {
 	 *
 	 * @see    API::request() For additional information
 	 *
-	 * @param  string $endpoint   	 GatherContent API endpoint to retrieve.
-	 * @param  string $expiration 	 The expiration time. Defaults to an hour.
-	 * @param  array  $args       	 Optional. Request arguments. Default empty array.
+	 * @param  string $endpoint      GatherContent API endpoint to retrieve.
+	 * @param  string $expiration    The expiration time. Defaults to an hour.
+	 * @param  array  $args          Optional. Request arguments. Default empty array.
 	 * @param  array  $query_params  Optional. Request query parameters to append to the URL. Default empty array.
 	 *
-	 * @return array              	 The response.
+	 * @return array                 The response.
 	 */
 	public function cache_get( $endpoint, $expiration = HOUR_IN_SECONDS, $args = array(), $method = 'get', $query_params = array() ) {
 
@@ -714,9 +714,9 @@ class API extends Base {
 	 *
 	 * @see    WP_Http::request() For additional information on default arguments.
 	 *
-	 * @param  string $endpoint 		GatherContent API endpoint to retrieve.
-	 * @param  array  $args     		Optional. Request arguments. Default empty array.
-	 * @param  array  $method   		Optional. Request method, defaults to 'GET'.
+	 * @param  string $endpoint         GatherContent API endpoint to retrieve.
+	 * @param  array  $args             Optional. Request arguments. Default empty array.
+	 * @param  array  $method           Optional. Request method, defaults to 'GET'.
 	 * @param  array  $query_params     Optional. Request query parameters to append to the URL. Default empty array.
 	 * @return array            The response.
 	 */
@@ -857,7 +857,7 @@ class API extends Base {
 	 * Sets the reset_request_cache flag and returns object, for chaining methods,
 	 * and flushing/bypassing cache for next request.
 	 *
-	 * e.g. `$this->uncached()->get( 'me' )`
+	 * E.g. `$this->uncached()->get( 'me' )`
 	 *
 	 * @since  3.0.0
 	 *

--- a/includes/classes/mapping-post.php
+++ b/includes/classes/mapping-post.php
@@ -174,7 +174,7 @@ class Mapping_Post extends Base {
 			$destination['type'] = $type[0];
 		}
 
-		if ( $sub_arg ) {
+		if ( $sub_arg && ! is_object( $sub_arg ) ) {
 			return is_array( $destination ) && isset( $destination[ $sub_arg ] ) ? $destination[ $sub_arg ] : false;
 		}
 
@@ -211,7 +211,7 @@ class Mapping_Post extends Base {
 	 * @return mixed        New item status or false.
 	 */
 	public function get_item_new_status( $item ) {
-		$status_id = isset( $item->custom_state_id ) ? $item->custom_state_id : $item;
+		$status_id = isset( $item->status_id ) ? $item->status_id : $item;
 		if ( $gc_status = $this->data( 'gc_status', $status_id ) ) {
 			if ( ! empty( $gc_status['after'] ) ) {
 				return absint( $gc_status['after'] );

--- a/includes/classes/sync/base.php
+++ b/includes/classes/sync/base.php
@@ -317,7 +317,7 @@ abstract class Base extends Plugin_Base {
 	protected function get_value_for_element( $element ) {
 		$val = false;
 
-		if( true === $element->repeatable ) {
+		if ( true === $element->repeatable ) {
 			return $element->value;
 		}
 
@@ -402,19 +402,33 @@ abstract class Base extends Plugin_Base {
 				break;
 
 			case 'attachment':
-				if ( is_array( $this->item->value ) ) {
-					$val = $this->item->value;
+				$element_values = is_array( $element->value ) ? $element->value : array();
+				$file_values    = array();
+				error_log( print_r( $element->value, true ) );
+				error_log( print_r( $this->item->files, true ) );
+
+				foreach ( $element_values as $value ) {
+					$file = array_values( wp_list_filter( $this->item->files, array( 'file_id' => $value->file_id ) ) );
+					error_log( print_r( $file, true ) );
+					error_log( $value->file_id );
+
+					if ( count( $file ) > 0 ) {
+						$file_values[] = $file[0];
+					}
 				}
+
+				error_log( print_r( $file_values, true ) );
+				$val = $file_values;
 				break;
 
 			default:
 				if ( isset( $element->value ) ) {
-					$val = sanitize_text_field( $option->label );
+					$val = sanitize_text_field( $element->label );
 				}
 				break;
 		}
 
-		return $val;
+			return $val;
 	}
 
 	/**
@@ -433,26 +447,26 @@ abstract class Base extends Plugin_Base {
 	 *
 	 * @since  3.2.0
 	 *
-	 * @param mixed 	  $field object
-	 * @param string|null $component_uuid optional component uuid only if the field is component
+	 * @param mixed       $field object.
+	 * @param string|null $component_uuid optional component uuid only if the field is component.
 	 * @return array
 	 */
-	protected function format_element_data($field, $component_uuid = ''): array {
+	protected function format_element_data( $field, $component_uuid = '' ): array {
 
-		$metadata 		= $field->metadata;
-		$field_name		= $field->uuid;
-		$is_repeatable  = (is_object($metadata) && isset($metadata->repeatable)) ? $metadata->repeatable->isRepeatable : false;
-		$is_plain		= 'text' === $field->field_type && is_object($metadata) ? $metadata->is_plain : false;
-		$content	    = $component_uuid ? ($this->item->content->$component_uuid ?? null) : $this->item->content;
-		$field_value	= $content ? ($content->$field_name ?? null) : null;
+		$metadata      = $field->metadata;
+		$field_name    = $field->uuid;
+		$is_repeatable = ( is_object( $metadata ) && isset( $metadata->repeatable ) ) ? $metadata->repeatable->isRepeatable : false;
+		$is_plain      = 'text' === $field->field_type && is_object( $metadata ) ? $metadata->is_plain : false;
+		$content       = $component_uuid ? ( $this->item->content->$component_uuid ?? null ) : $this->item->content;
+		$field_value   = $content ? ( $content->$field_name ?? null ) : null;
 
 		return array(
-			'name'			=> $field_name,
-			'type'			=> $field->field_type,
-			'label' 		=> $field->label,
-			'plain_text'	=> (bool) $is_plain,
-			'value'			=> $field_value && $is_repeatable ? wp_json_encode($field_value) : $field_value,
-			'repeatable'	=> (bool) $is_repeatable
+			'name'       => $field_name,
+			'type'       => $field->field_type,
+			'label'      => $field->label,
+			'plain_text' => (bool) $is_plain,
+			'value'      => $field_value && $is_repeatable ? wp_json_encode( $field_value ) : $field_value,
+			'repeatable' => (bool) $is_repeatable,
 		);
 	}
 

--- a/includes/classes/sync/pull.php
+++ b/includes/classes/sync/pull.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * GatherContent Plugin
  *
@@ -16,7 +17,8 @@ use WP_Error;
  *
  * @since 3.0.0
  */
-class Pull extends Base {
+class Pull extends Base
+{
 
 	/**
 	 * Sync direction.
@@ -32,9 +34,9 @@ class Pull extends Base {
 	 *
 	 * @param API $api API object.
 	 */
-	public function __construct( API $api ) {
-		parent::__construct( $api, new Async_Pull_Action() );
-
+	public function __construct(API $api)
+	{
+		parent::__construct($api, new Async_Pull_Action());
 	}
 
 	/**
@@ -44,8 +46,9 @@ class Pull extends Base {
 	 *
 	 * @return void
 	 */
-	public static function init_plugins_loaded_hooks() {
-		add_action( 'gc_associate_hierarchy', array( __CLASS__, 'associate_hierarchy' ) );
+	public static function init_plugins_loaded_hooks()
+	{
+		add_action('gc_associate_hierarchy', array(__CLASS__, 'associate_hierarchy'));
 	}
 
 	/**
@@ -55,11 +58,12 @@ class Pull extends Base {
 	 *
 	 * @return void
 	 */
-	public function init_hooks() {
+	public function init_hooks()
+	{
 		parent::init_hooks();
-		add_action( 'wp_async_gc_pull_items', array( $this, 'sync_items' ) );
-		add_action( 'wp_async_nopriv_gc_pull_items', array( $this, 'sync_items' ) );
-		add_action( 'gc_pull_complete', array( __CLASS__, 'associate_hierarchy' ) );
+		add_action('wp_async_gc_pull_items', array($this, 'sync_items'));
+		add_action('wp_async_nopriv_gc_pull_items', array($this, 'sync_items'));
+		add_action('gc_pull_complete', array(__CLASS__, 'associate_hierarchy'));
 	}
 
 	/**
@@ -72,13 +76,14 @@ class Pull extends Base {
 	 *
 	 * @return mixed Result of pull. WP_Error on failure.
 	 */
-	public function maybe_pull_item( $mapping_post, $item_id ) {
+	public function maybe_pull_item($mapping_post, $item_id)
+	{
 
 		try {
-			$this->mapping = Mapping_Post::get( $mapping_post, true );
-			$result        = $this->do_item( $item_id );
-		} catch ( \Exception $e ) {
-			$result = new WP_Error( 'gc_pull_item_fail_' . $e->getCode(), $e->getMessage(), $e->get_data() );
+			$this->mapping = Mapping_Post::get($mapping_post, true);
+			$result        = $this->do_item($item_id);
+		} catch (\Exception $e) {
+			$result = new WP_Error('gc_pull_item_fail_' . $e->getCode(), $e->getMessage(), $e->get_data());
 		}
 
 		return $result;
@@ -95,31 +100,31 @@ class Pull extends Base {
 	 *
 	 * @return mixed Result of pull.
 	 */
-	protected function do_item( $id ) {
+	protected function do_item($id)
+	{
 
-		$this->check_mapping_data( $this->mapping );
+		$this->check_mapping_data($this->mapping);
 
-		$this->set_item( $id );
+		$this->set_item($id);
 
 		$post_data   = array();
 		$attachments = $tax_terms = false;
 
-		if ( $existing = \GatherContent\Importer\get_post_by_item_id( $id ) ) {
+		if ($existing = \GatherContent\Importer\get_post_by_item_id($id)) {
 			// Check if item is up-to-date and if pull is necessary.
-			$meta       = \GatherContent\Importer\get_post_item_meta( $existing->ID );
-			$updated_at = isset( $meta['updated_at'] ) ? $meta['updated_at'] : 0;
-			$updated_at = is_object( $updated_at ) ? $updated_at->date : $updated_at;
+			$meta       = \GatherContent\Importer\get_post_item_meta($existing->ID);
+			$updated_at = isset($meta['updated_at']) ? $meta['updated_at'] : 0;
 
 			if (
 				// Check if we have updated_at values to compare.
-				isset( $this->item->updated_at ) && ! empty( $updated_at )
+				isset($this->item->updated_at) && !empty($updated_at)
 				// And if we do, compare them to see if GC item is newer.
-				&& ( $is_up_to_date = strtotime( $this->item->updated_at->date ) <= strtotime( $updated_at ) )
+				&& ($is_up_to_date = strtotime($this->item->updated_at) <= strtotime($updated_at))
 				// If it's not newer, then don't update (unless asked to via filter).
-				&& $is_up_to_date && apply_filters( 'gc_only_update_if_newer', true )
+				&& $is_up_to_date && apply_filters('gc_only_update_if_newer', true)
 			) {
 				throw new Exception(
-					sprintf( __( 'WordPress has most recent changes for %1$s (Item ID: %2$d):', 'gathercontent-import' ), $this->item->name, $this->item->id ),
+					sprintf(__('WordPress has most recent changes for %1$s (Item ID: %2$d):', 'gathercontent-import'), $this->item->name, $this->item->id),
 					__LINE__,
 					array(
 						'post' => $existing->ID,
@@ -133,78 +138,78 @@ class Pull extends Base {
 			$post_data['ID'] = 0;
 		}
 
-		$post_data = $this->map_gc_data_to_wp_data( $post_data );
+		$post_data = $this->map_gc_data_to_wp_data($post_data);
 
-		if ( ! empty( $post_data['attachments'] ) ) {
+		if (!empty($post_data['attachments'])) {
 			$attachments = $post_data['attachments'];
-			unset( $post_data['attachments'] );
+			unset($post_data['attachments']);
 		}
 
-		if ( ! empty( $post_data['tax_input'] ) ) {
+		if (!empty($post_data['tax_input'])) {
 			$tax_terms = $post_data['tax_input'];
-			unset( $post_data['tax_input'] );
+			unset($post_data['tax_input']);
 		}
 
-		$post_id = wp_insert_post( $post_data, 1 );
+		$post_id = wp_insert_post($post_data, 1);
 
-		if ( is_wp_error( $post_id ) ) {
-			throw new Exception( $post_id->get_error_message(), __LINE__, $post_id->get_error_data() );
+		if (is_wp_error($post_id)) {
+			throw new Exception($post_id->get_error_message(), __LINE__, $post_id->get_error_data());
 		}
 
 		$post_data['ID'] = $post_id;
 
 		// Store item ID reference to post-meta.
-		\GatherContent\Importer\update_post_item_id( $post_id, $id );
-		\GatherContent\Importer\update_post_mapping_id( $post_id, $this->mapping->ID );
+		\GatherContent\Importer\update_post_item_id($post_id, $id);
+		\GatherContent\Importer\update_post_mapping_id($post_id, $this->mapping->ID);
 		\GatherContent\Importer\update_post_item_meta(
 			$post_id,
 			array(
-				'created_at' => $this->item->created_at->date,
-				'updated_at' => $this->item->updated_at->date,
+				'created_at' => $this->item->created_at,
+				'updated_at' => $this->item->updated_at,
 			)
 		);
 
-		if ( ! empty( $tax_terms ) ) {
-			foreach ( $tax_terms as $taxonomy => $terms ) {
-				$taxonomy_obj = get_taxonomy( $taxonomy );
-				if ( ! $taxonomy_obj ) {
+		if (!empty($tax_terms)) {
+			foreach ($tax_terms as $taxonomy => $terms) {
+				$taxonomy_obj = get_taxonomy($taxonomy);
+				if (!$taxonomy_obj) {
 					/* translators: %s: taxonomy name */
-					_doing_it_wrong( __FUNCTION__, sprintf( __( 'Invalid taxonomy: %s.' ), $taxonomy ), '4.4.0' );
+					_doing_it_wrong(__FUNCTION__, sprintf(__('Invalid taxonomy: %s.'), $taxonomy), '4.4.0');
 					continue;
 				}
 
 				// array = hierarchical, string = non-hierarchical.
-				if ( is_array( $terms ) ) {
-					$terms = array_filter( $terms );
+				if (is_array($terms)) {
+					$terms = array_filter($terms);
 				}
 
 				// Set post terms without the cap-check.
-				wp_set_post_terms( $post_id, $terms, $taxonomy );
+				wp_set_post_terms($post_id, $terms, $taxonomy);
 			}
 		}
 
 		$updated_post_data = array();
 
-		if ( $attachments ) {
-			$attachments  = apply_filters( 'gc_media_objects', $attachments, $post_data );
-			$replacements = $this->sideload_attachments( $attachments, $post_data );
+		if ($attachments) {
+			$attachments  = apply_filters('gc_media_objects', $attachments, $post_data);
+			$replacements = $this->sideload_attachments($attachments, $post_data);
 
-			if ( ! empty( $replacements ) ) {
+			if (!empty($replacements)) {
 				// Do replacements.
-				if ( ! empty( $replacements['post_content'] ) ) {
-					$updated_post_data['post_content'] = strtr( $post_data['post_content'], $replacements['post_content'] );
+				if (!empty($replacements['post_content'])) {
+					$updated_post_data['post_content'] = strtr($post_data['post_content'], $replacements['post_content']);
 				}
 
-				if ( ! empty( $replacements['post_excerpt'] ) ) {
-					$updated_post_data['post_excerpt'] = strtr( $post_data['post_excerpt'], $replacements['post_excerpt'] );
+				if (!empty($replacements['post_excerpt'])) {
+					$updated_post_data['post_excerpt'] = strtr($post_data['post_excerpt'], $replacements['post_excerpt']);
 				}
 
-				if ( ! empty( $replacements['meta_input'] ) ) {
+				if (!empty($replacements['meta_input'])) {
 					$updated_post_data['meta_input'] = array_map(
-						function( $meta ) {
-							return is_array( $meta ) && count( $meta ) > 1
-							? $meta
-							: array_shift( $meta );
+						function ($meta) {
+							return is_array($meta) && count($meta) > 1
+								? $meta
+								: array_shift($meta);
 						},
 						$replacements['meta_input']
 					);
@@ -231,14 +236,14 @@ class Pull extends Base {
 			}
 		}*/
 
-		if ( ! empty( $updated_post_data ) ) {
+		if (!empty($updated_post_data)) {
 			// And update post (but don't create a revision for it).
-			self::post_update_no_revision( array_merge( $post_data, $updated_post_data ) );
+			self::post_update_no_revision(array_merge($post_data, $updated_post_data));
 		}
 
-		if ( $status = $this->mapping->get_item_new_status( $this->item ) ) {
+		if ($status = $this->mapping->get_item_new_status($this->item)) {
 			// Update the GC item status.
-			$this->api->set_item_status( $id, $status );
+			$this->api->set_item_status($id, $status);
 		}
 
 		return $post_id;
@@ -253,54 +258,56 @@ class Pull extends Base {
 	 *
 	 * @return array Item config array on success.
 	 */
-	protected function map_gc_data_to_wp_data( $post_data = array() ) {
-		$this->check_mapping_data( $this->mapping );
+	protected function map_gc_data_to_wp_data($post_data = array())
+	{
 
-		foreach ( array( 'post_author', 'post_status', 'post_type' ) as $key ) {
-			$post_data[ $key ] = $this->mapping->data( $key );
+		$this->check_mapping_data($this->mapping);
+
+		foreach (array('post_author', 'post_status', 'post_type') as $key) {
+			$post_data[$key] = $this->mapping->data($key);
 		}
 
-		$status = $this->mapping->get_wp_status_for_item( $this->item );
-		if ( $status && 'nochange' !== $status ) {
+		$status = $this->mapping->get_wp_status_for_item($this->item);
+		if ($status && 'nochange' !== $status) {
 			$post_data['post_status'] = $status;
 		}
 
 		$backup = array();
-		foreach ( $this->append_types as $key ) {
-			$backup[ $key ]    = isset( $post_data[ $key ] ) ? $post_data[ $key ] : '';
-			$post_data[ $key ] = 'gcinitial';
+		foreach ($this->append_types as $key) {
+			$backup[$key]    = isset($post_data[$key]) ? $post_data[$key] : '';
+			$post_data[$key] = 'gcinitial';
 		}
 
-		$files = $this->api->uncached()->get_item_files( $this->item->id );
+		// $files = $this->api->uncached()->get_item_files($this->item->id);
 
-		$this->item->files = array();
-		if ( is_array( $files ) ) {
-			foreach ( $files as $file ) {
-				$this->item->files[ $file->field ][] = $file;
-			}
+		// $this->item->files = array();
+		// if (is_array($files)) {
+		// 	foreach ($files as $file) {
+		// 		$this->item->files[$file->field][] = $file;
+		// 	}
+		// }
+
+		if ($this->should_map_hierarchy($post_data['post_type']) && isset($this->item->position)) {
+			$post_data['menu_order'] = absint($this->item->position);
 		}
 
-		if ( $this->should_map_hierarchy( $post_data['post_type'] ) && isset( $this->item->position ) ) {
-			$post_data['menu_order'] = absint( $this->item->position );
-		}
-
-		$post_data = $this->loop_item_elements_and_map( $post_data );
+		$post_data = $this->loop_item_elements_and_map($post_data);
 
 		// Put the backup data back.
-		foreach ( $backup as $key => $value ) {
-			if ( 'gcinitial' === $post_data[ $key ] ) {
-				$post_data[ $key ] = $value;
+		foreach ($backup as $key => $value) {
+			if ('gcinitial' === $post_data[$key]) {
+				$post_data[$key] = $value;
 			}
 		}
 
-		if ( $this->should_update_title_with_item_name( $post_data ) ) {
-			$post_data['post_title'] = sanitize_text_field( $this->item->name );
+		if ($this->should_update_title_with_item_name($post_data)) {
+			$post_data['post_title'] = sanitize_text_field($this->item->name);
 		}
 
-		if ( ! empty( $post_data['ID'] ) ) {
-			$post_data = apply_filters( 'gc_update_wp_post_data', $post_data, $this );
+		if (!empty($post_data['ID'])) {
+			$post_data = apply_filters('gc_update_wp_post_data', $post_data, $this);
 		} else {
-			$post_data = apply_filters( 'gc_new_wp_post_data', $post_data, $this );
+			$post_data = apply_filters('gc_new_wp_post_data', $post_data, $this);
 		}
 
 		return $post_data;
@@ -315,11 +322,12 @@ class Pull extends Base {
 	 *
 	 * @return boolean
 	 */
-	public function should_update_title_with_item_name( $post_data ) {
-		$should      = ! empty( $this->item->name );
-		$empty_title = empty( $post_data['post_title'] );
-		if ( ! $empty_title ) {
-			$should = ! $this->has_post_title_mapping();
+	public function should_update_title_with_item_name($post_data)
+	{
+		$should      = !empty($this->item->name);
+		$empty_title = empty($post_data['post_title']);
+		if (!$empty_title) {
+			$should = !$this->has_post_title_mapping();
 		}
 
 		return $should;
@@ -332,26 +340,29 @@ class Pull extends Base {
 	 *
 	 * @return boolean
 	 */
-	public function has_post_title_mapping() {
+	public function has_post_title_mapping()
+	{
 		try {
 			array_filter(
 				$this->mapping->data(),
-				function( $mapped ) {
-					if ( isset( $mapped['type'], $mapped['value'] )
-					&& 'wp-type-post' === $mapped['type']
-					&& 'post_title' === $mapped['value'] ) {
-						throw new \Exception( 'found' );
+				function ($mapped) {
+					if (
+						isset($mapped['type'], $mapped['value'])
+						&& 'wp-type-post' === $mapped['type']
+						&& 'post_title' === $mapped['value']
+					) {
+						throw new \Exception('found');
 					}
 				}
 			);
-		} catch ( \Exception $e ) {
+		} catch (\Exception $e) {
 			return true;
 		}
 		return false;
 	}
 
 	/**
-	 * Loops the GC item config elements and maps the WP post data.
+	 * Loops the GC item content elements and maps the WP post data.
 	 *
 	 * @since  3.0.0
 	 *
@@ -359,36 +370,49 @@ class Pull extends Base {
 	 *
 	 * @return array Modified post data array on success.
 	 */
-	protected function loop_item_elements_and_map( $post_data ) {
+	protected function loop_item_elements_and_map($post_data)
+	{
 
-		if ( ! isset( $this->item->config ) || empty( $this->item->config ) ) {
+		$structure_groups = $this->item->structure->groups;
+
+		if ( ! isset( $structure_groups ) || empty( $structure_groups ) ) {
 			return $post_data;
 		}
 
-		$columns = array();
+		$columns = [];
 
-		foreach ( $this->item->config as $tab ) {
-			if ( ! isset( $tab->elements ) || ! $tab->elements ) {
+		// to handle multiple tabs
+		foreach ( $structure_groups as $tab ) {
+			if ( ! isset( $tab->fields ) || ! $tab->fields ) {
 				continue;
 			}
 
-			foreach ( $tab->elements as $this->element ) {
+			// to handle fields in a tab
+			foreach ( $tab->fields as $field ) {
 
-				$destination = $this->mapping->data( $this->element->name );
+				// to handle components with multiple fields inside
+				$fields_data    = $field->component->fields ?? [$field];
+				$component_uuid = 'component' === $field->field_type ? $field->uuid : '';
 
-				if ( $destination && isset( $destination['type'], $destination['value'] ) ) {
-					$columns[ $destination['value'] ] = true;
-					$post_data                        = $this->set_post_values( $destination, $post_data );
+				foreach ($fields_data as $field_data) {
+					$this->element	=  (object) $this->format_element_data( $field_data, $component_uuid );
+					$destination 	= $this->mapping->data( $this->element->name );
+
+					if ( $destination && isset( $destination['type'], $destination['value'] ) ) {
+						$columns[ $destination['value'] ] = true;
+						$post_data = $this->set_post_values( $destination, $post_data );
+					}
 				}
 			}
 		}
 
-		if ( isset( $columns['post_date'] ) && ! isset( $columns['post_date_gmt'] ) ) {
-			$post_data['post_date_gmt'] = get_gmt_from_date( $post_data['post_date'] );
+
+		if (isset($columns['post_date']) && !isset($columns['post_date_gmt'])) {
+			$post_data['post_date_gmt'] = get_gmt_from_date($post_data['post_date']);
 		}
 
-		if ( isset( $columns['post_modified'] ) && ! isset( $columns['post_modified_gmt'] ) ) {
-			$post_data['post_modified_gmt'] = get_gmt_from_date( $post_data['post_modified'] );
+		if (isset($columns['post_modified']) && !isset($columns['post_modified_gmt'])) {
+			$post_data['post_modified_gmt'] = get_gmt_from_date($post_data['post_modified']);
 		}
 
 		return $post_data;
@@ -404,31 +428,32 @@ class Pull extends Base {
 	 *
 	 * @return array $post_data   The modified WP Post data array.
 	 */
-	protected function set_post_values( $destination, $post_data ) {
+	protected function set_post_values($destination, $post_data)
+	{
 
 		$this->set_element_value();
 
 		try {
-			switch ( $destination['type'] ) {
+			switch ($destination['type']) {
 
 				case 'wp-type-post':
-					$post_data = $this->set_post_field_value( $destination['value'], $post_data );
+					$post_data = $this->set_post_field_value($destination['value'], $post_data);
 					break;
 
 				case 'wp-type-taxonomy':
-					$post_data = $this->set_taxonomy_field_value( $destination['value'], $post_data );
+					$post_data = $this->set_taxonomy_field_value($destination['value'], $post_data);
 					break;
 
 				case 'wp-type-meta':
-					$post_data = $this->set_meta_field_value( $destination['value'], $post_data );
+					$post_data = $this->set_meta_field_value($destination['value'], $post_data);
 					break;
 
 				case 'wp-type-media':
-					$post_data = $this->set_media_field_value( $destination['value'], $post_data );
+					$post_data = $this->set_media_field_value($destination['value'], $post_data);
 					break;
 			}
-		// @codingStandardsIgnoreStart
-		} catch ( \Exception $e ) {
+			// @codingStandardsIgnoreStart
+		} catch (\Exception $e) {
 			// @todo logging?
 		}
 		// @codingStandardsIgnoreEnd
@@ -446,15 +471,16 @@ class Pull extends Base {
 	 *
 	 * @return array $post_data   The modified WP Post data array.
 	 */
-	protected function set_post_field_value( $post_column, $post_data ) {
+	protected function set_post_field_value($post_column, $post_data)
+	{
 
-		if ( is_array( $this->element->value ) ) {
-			$this->element->value = implode( ', ', $this->element->value );
+		if (is_array($this->element->value)) {
+			$this->element->value = implode(', ', $this->element->value);
 		}
 
-		$value = $this->sanitize_post_field( $post_column, $this->element->value, $post_data );
+		$value = $this->sanitize_post_field($post_column, $this->element->value, $post_data);
 
-		return $this->maybe_append( $post_column, $value, $post_data );
+		return $this->maybe_append($post_column, $value, $post_data);
 	}
 
 	/**
@@ -467,14 +493,15 @@ class Pull extends Base {
 	 *
 	 * @return array $post_data  The modified WP Post data array.
 	 */
-	protected function set_taxonomy_field_value( $taxonomy, $post_data ) {
-		$terms = $this->get_element_terms( $taxonomy );
-		$terms = array_filter( $terms );
-		if ( ! empty( $terms ) ) {
-			if ( 'category' === $taxonomy ) {
+	protected function set_taxonomy_field_value($taxonomy, $post_data)
+	{
+		$terms = $this->get_element_terms($taxonomy);
+		$terms = array_filter($terms);
+		if (!empty($terms)) {
+			if ('category' === $taxonomy) {
 				$post_data['post_category'] = $terms;
 			} else {
-				$post_data['tax_input'][ $taxonomy ] = $terms;
+				$post_data['tax_input'][$taxonomy] = $terms;
 			}
 		}
 
@@ -491,16 +518,17 @@ class Pull extends Base {
 	 *
 	 * @return array  $post_data The modified WP Post data array.
 	 */
-	protected function set_meta_field_value( $meta_key, $post_data ) {
+	protected function set_meta_field_value($meta_key, $post_data)
+	{
 		$value = $this->sanitize_element_meta();
-		if ( ! isset( $post_data['meta_input'] ) ) {
+		if (!isset($post_data['meta_input'])) {
 			$post_data['meta_input'] = array();
 		}
 
-		$post_data['meta_input'] = $this->maybe_append( $meta_key, $value, $post_data['meta_input'] );
+		$post_data['meta_input'] = $this->maybe_append($meta_key, $value, $post_data['meta_input']);
 
-		if ( 'files' === $this->element->type ) {
-			$post_data = $this->set_media_field_value( $meta_key, $post_data );
+		if ('files' === $this->element->type) {
+			$post_data = $this->set_media_field_value($meta_key, $post_data);
 		}
 
 		return $post_data;
@@ -516,25 +544,26 @@ class Pull extends Base {
 	 *
 	 * @return array  $post_data   The modified WP Post data array.
 	 */
-	protected function set_media_field_value( $destination, $post_data ) {
+	protected function set_media_field_value($destination, $post_data)
+	{
 
 		static $field_number = 0;
 		$media_items         = $this->sanitize_element_media();
 
 		if (
-			in_array( $destination, array( 'gallery', 'content_image', 'excerpt_image' ), true )
-			&& is_array( $media_items )
+			in_array($destination, array('gallery', 'content_image', 'excerpt_image'), true)
+			&& is_array($media_items)
 		) {
 			$field_number++;
 			$position = 0;
-			foreach ( $media_items as $index => $media ) {
-				$media_items[ $index ]->position     = ++$position;
-				$media_items[ $index ]->field_number = $field_number;
+			foreach ($media_items as $index => $media) {
+				$media_items[$index]->position     = ++$position;
+				$media_items[$index]->field_number = $field_number;
 
 				$token = '#_gc_media_id_' . $media->id . '#';
 				$field = 'excerpt_image' === $destination ? 'post_excerpt' : 'post_content';
 
-				$post_data = $this->maybe_append( $field, $token, $post_data );
+				$post_data = $this->maybe_append($field, $token, $post_data);
 			}
 		}
 
@@ -557,15 +586,16 @@ class Pull extends Base {
 	 *
 	 * @return array         The modified array.
 	 */
-	protected function maybe_append( $field, $value, $array ) {
-		if ( $this->type_can_append( $field ) ) {
-			$array[ $field ] = isset( $array[ $field ] ) ? $array[ $field ] : '';
-			if ( 'gcinitial' === $array[ $field ] ) {
-				$array[ $field ] = '';
+	protected function maybe_append($field, $value, $array)
+	{
+		if ($this->type_can_append($field)) {
+			$array[$field] = isset($array[$field]) ? $array[$field] : '';
+			if ('gcinitial' === $array[$field]) {
+				$array[$field] = '';
 			}
-			$array[ $field ] .= $value;
+			$array[$field] .= $value;
 		} else {
-			$array[ $field ] = $value;
+			$array[$field] = $value;
 		}
 
 		return $array;
@@ -585,38 +615,38 @@ class Pull extends Base {
 	 *
 	 * @return mixed             The sanitized post field value.
 	 */
-	protected function sanitize_post_field( $field, $value, $post_data ) {
-		if ( ! $value ) {
+	protected function sanitize_post_field($field, $value, $post_data)
+	{
+		if (!$value) {
 			return $value;
 		}
 
-		switch ( $field ) {
+		switch ($field) {
 			case 'ID':
-				throw new Exception( __( 'Cannot override post IDs', 'gathercontent-import' ), __LINE__ );
+				throw new Exception(__('Cannot override post IDs', 'gathercontent-import'), __LINE__);
 
 			case 'post_date':
 			case 'post_date_gmt':
 			case 'post_modified':
 			case 'post_modified_gmt':
-				if ( ! is_string( $value ) && ! is_numeric( $value ) ) {
-					throw new Exception( sprintf( __( '%s field requires a numeric timestamp, or date string.', 'gathercontent-import' ), $field ), __LINE__ );
+				if (!is_string($value) && !is_numeric($value)) {
+					throw new Exception(sprintf(__('%s field requires a numeric timestamp, or date string.', 'gathercontent-import'), $field), __LINE__);
 				}
 
-				$value = is_numeric( $value ) ? $value : strtotime( $value );
+				$value = is_numeric($value) ? $value : strtotime($value);
 
-				return false !== strpos( $field, '_gmt' )
-					? gmdate( 'Y-m-d H:i:s', $value )
-					: date( 'Y-m-d H:i:s', $value );
+				return false !== strpos($field, '_gmt')
+					? gmdate('Y-m-d H:i:s', $value)
+					: date('Y-m-d H:i:s', $value);
 			case 'post_format':
-				if ( isset( $post_data['post_type'] ) && ! post_type_supports( $post_data['post_type'], 'post-formats' ) ) {
-					throw new Exception( sprintf( __( 'The %s post-type does not support post-formats.', 'gathercontent-import' ), $post_data['post_type'] ), __LINE__ );
+				if (isset($post_data['post_type']) && !post_type_supports($post_data['post_type'], 'post-formats')) {
+					throw new Exception(sprintf(__('The %s post-type does not support post-formats.', 'gathercontent-import'), $post_data['post_type']), __LINE__);
 				}
 			case 'post_title':
-				$value = strip_tags( $value, '<strong><em><del><ins><code>' );
-
+				$value = strip_tags($value, '<strong><em><del><ins><code>');
 		}
 
-		return sanitize_post_field( $field, $value, $post_data['ID'], 'db' );
+		return sanitize_post_field($field, $value, $post_data['ID'], 'db');
 	}
 
 	/**
@@ -628,33 +658,34 @@ class Pull extends Base {
 	 *
 	 * @return mixed            The terms.
 	 */
-	protected function get_element_terms( $taxonomy ) {
-		if ( 'text' === $this->element->type ) {
-			$terms = array_map( 'trim', explode( ',', sanitize_text_field( $this->element->value ) ) );
+	protected function get_element_terms($taxonomy)
+	{
+		if ('text' === $this->element->type) {
+			$terms = array_map('trim', explode(',', sanitize_text_field($this->element->value)));
 		} else {
 			$terms = (array) $this->element->value;
 		}
 
-		if ( ! empty( $terms ) && is_taxonomy_hierarchical( $taxonomy ) ) {
-			foreach ( $terms as $key => $term ) {
+		if (!empty($terms) && is_taxonomy_hierarchical($taxonomy)) {
+			foreach ($terms as $key => $term) {
 				// @codingStandardsIgnoreStart
-				if ( ! $term_info = term_exists( $term, $taxonomy ) ) {
+				if (!$term_info = term_exists($term, $taxonomy)) {
 					// @codingStandardsIgnoreEnd
 					// Skip if a non-existent term ID is passed.
-					if ( is_int( $term ) ) {
-						unset( $terms[ $key ] );
+					if (is_int($term)) {
+						unset($terms[$key]);
 						continue;
 					}
-					$term_info = wp_insert_term( $term, $taxonomy );
+					$term_info = wp_insert_term($term, $taxonomy);
 				}
 
-				if ( ! is_wp_error( $term_info ) ) {
-					$terms[ $key ] = $term_info['term_id'];
+				if (!is_wp_error($term_info)) {
+					$terms[$key] = $term_info['term_id'];
 				}
 			}
 		}
 
-		return apply_filters( 'gc_get_element_terms', $terms, $this->element, $this->item );
+		return apply_filters('gc_get_element_terms', $terms, $this->element, $this->item);
 	}
 
 	/**
@@ -665,8 +696,9 @@ class Pull extends Base {
 	 *
 	 * @return mixed Value for meta.
 	 */
-	protected function sanitize_element_meta() {
-		return apply_filters( 'gc_sanitize_meta_field', $this->element->value, $this->element, $this->item );
+	protected function sanitize_element_meta()
+	{
+		return apply_filters('gc_sanitize_meta_field', $this->element->value, $this->element, $this->item);
 	}
 
 	/*
@@ -681,10 +713,10 @@ class Pull extends Base {
 	 *
 	 * @return mixed Value for media.
 	 */
-	protected function sanitize_element_media() {
+	protected function sanitize_element_media()
+	{
 
-		return apply_filters( 'gc_sanitize_media_field', $this->element->value, $this->element, $this->item );
-
+		return apply_filters('gc_sanitize_media_field', $this->element->value, $this->element, $this->item);
 	}
 
 	/**
@@ -699,80 +731,78 @@ class Pull extends Base {
 	 *
 	 * @return array              Array of replacement key/values for strtr.
 	 */
-	protected function sideload_attachments( $attachments, $post_data ) {
+	protected function sideload_attachments($attachments, $post_data)
+	{
 
 		$post_id         = $post_data['ID'];
 		$featured_img_id = false;
 
 		$replacements = $gallery_ids = array();
 
-		foreach ( $attachments as $attachment ) {
-			if ( ! is_array( $attachment['media'] ) ) {
+		foreach ($attachments as $attachment) {
+			if (!is_array($attachment['media'])) {
 				continue;
 			}
 
-			foreach ( $attachment['media'] as $media ) {
-				$attach_id = $this->maybe_sideload_file( $media, $post_id );
+			foreach ($attachment['media'] as $media) {
+				$attach_id = $this->maybe_sideload_file($media, $post_id);
 
-				if ( ! $attach_id || is_wp_error( $attach_id ) ) {
+				if (!$attach_id || is_wp_error($attach_id)) {
 					// @todo How to handle failures?
 					continue;
 				}
 
 				$token = '#_gc_media_id_' . $media->id . '#';
 
-				if ( self::attachment_is_image( $attach_id ) ) {
-					if ( 'featured_image' === $attachment['destination'] ) {
+				if (self::attachment_is_image($attach_id)) {
+					if ('featured_image' === $attachment['destination']) {
 						$featured_img_id = $attach_id;
-					} elseif ( in_array( $attachment['destination'], array( 'content_image', 'excerpt_image' ), true ) ) {
+					} elseif (in_array($attachment['destination'], array('content_image', 'excerpt_image'), true)) {
 						$field = 'excerpt_image' === $attachment['destination'] ? 'post_excerpt' : 'post_content';
 
 						$atts  = array(
 							'data-gcid' => $media->id,
 							'class'     => "gathercontent-image attachment-full size-full wp-image-$attach_id",
 						);
-						$image = wp_get_attachment_image( $attach_id, 'full', false, $atts );
+						$image = wp_get_attachment_image($attach_id, 'full', false, $atts);
 
 						// If we've found a GC "shortcode"...
-						if ( $media_replace = $this->get_media_shortcode_attributes( $post_data[ $field ], (array) $media ) ) {
+						if ($media_replace = $this->get_media_shortcode_attributes($post_data[$field], (array) $media)) {
 
-							foreach ( $media_replace as $replace_val => $atts ) {
+							foreach ($media_replace as $replace_val => $atts) {
 
-								$maybe_image = ! empty( $atts )
+								$maybe_image = !empty($atts)
 									// Attempt to get requested image/link.
-									? $this->get_requested_media( $atts, $media->id, $attach_id )
+									? $this->get_requested_media($atts, $media->id, $attach_id)
 									: false;
 
 								$img = $maybe_image ? $maybe_image : $image;
 
 								// Replace the GC "shortcode" with the image/link.
-								$img                                    = apply_filters( 'gc_content_image', $img, $media, $attach_id, $post_data, $atts );
-								$replacements[ $field ][ $replace_val ] = $img;
+								$img                                    = apply_filters('gc_content_image', $img, $media, $attach_id, $post_data, $atts);
+								$replacements[$field][$replace_val] = $img;
 							}
 
 							// The token should be removed from the content.
-							$replacements[ $field ][ $token ] = '';
-
+							$replacements[$field][$token] = '';
 						} else {
 
 							// Replace the token with the image.
-							$image                            = apply_filters( 'gc_content_image', $image, $media, $attach_id, $post_data, $atts );
-							$replacements[ $field ][ $token ] = $image;
-
+							$image                            = apply_filters('gc_content_image', $image, $media, $attach_id, $post_data, $atts);
+							$replacements[$field][$token] = $image;
 						}
-					} elseif ( 'gallery' === $attachment['destination'] ) {
+					} elseif ('gallery' === $attachment['destination']) {
 
 						$gallery_ids[] = $attach_id;
 						$gallery_token = $token;
 
 						// The token should be removed from the content.
-						$replacements['post_content'][ $token ] = '';
-
+						$replacements['post_content'][$token] = '';
 					} else {
-						$replacements['meta_input'][ $attachment['destination'] ][] = $attach_id;
+						$replacements['meta_input'][$attachment['destination']][] = $attach_id;
 					}
 				} else { // NOT is_image
-					if ( in_array( $attachment['destination'], array( 'content_image', 'excerpt_image' ), true ) ) {
+					if (in_array($attachment['destination'], array('content_image', 'excerpt_image'), true)) {
 						$field = 'excerpt_image' === $attachment['destination'] ? 'post_excerpt' : 'post_content';
 
 						$atts = array(
@@ -780,35 +810,33 @@ class Pull extends Base {
 							'class'     => "gathercontent-file wp-file-$attach_id",
 						);
 
-						$link = '<a href="' . esc_url( wp_get_attachment_url( $attach_id ) ) . '" data-gcid="' . $atts['data-gcid'] . '" class="' . $atts['class'] . '">' . get_the_title( $attach_id ) . '</a>';
+						$link = '<a href="' . esc_url(wp_get_attachment_url($attach_id)) . '" data-gcid="' . $atts['data-gcid'] . '" class="' . $atts['class'] . '">' . get_the_title($attach_id) . '</a>';
 
 						// If we've found a GC "shortcode"...
-						if ( $media_replace = $this->get_media_shortcode_attributes( $post_data[ $field ], (array) $media ) ) {
+						if ($media_replace = $this->get_media_shortcode_attributes($post_data[$field], (array) $media)) {
 
-							foreach ( $media_replace as $replace_val => $atts ) {
+							foreach ($media_replace as $replace_val => $atts) {
 								// Replace the GC "shortcode" with the file/link.
-								$link                                   = apply_filters( 'gc_content_file', $link, $media, $attach_id, $post_data, $atts );
-								$replacements[ $field ][ $replace_val ] = $link;
+								$link                                   = apply_filters('gc_content_file', $link, $media, $attach_id, $post_data, $atts);
+								$replacements[$field][$replace_val] = $link;
 							}
 
 							// The token should be removed from the content.
-							$replacements[ $field ][ $token ] = '';
-
+							$replacements[$field][$token] = '';
 						} else {
 
 							// Replace the token with the image.
-							$link                             = apply_filters( 'gc_content_file', $link, $media, $attach_id, $post_data, $atts );
-							$replacements[ $field ][ $token ] = $link;
-
+							$link                             = apply_filters('gc_content_file', $link, $media, $attach_id, $post_data, $atts);
+							$replacements[$field][$token] = $link;
 						}
 					} else {
-						$replacements['meta_input'][ $attachment['destination'] ][] = $attach_id;
+						$replacements['meta_input'][$attachment['destination']][] = $attach_id;
 					}
 				}
 
 				// Store media item ID reference to attachment post-meta.
-				\GatherContent\Importer\update_post_item_id( $attach_id, $media->id );
-				\GatherContent\Importer\update_post_mapping_id( $attach_id, $this->mapping->ID );
+				\GatherContent\Importer\update_post_item_id($attach_id, $media->id);
+				\GatherContent\Importer\update_post_mapping_id($attach_id, $this->mapping->ID);
 
 				// Store other media item meta to attachment post-meta.
 				\GatherContent\Importer\update_post_item_meta(
@@ -821,26 +849,26 @@ class Pull extends Base {
 						'url'        => $media->url,
 						'filename'   => $media->filename,
 						'size'       => $media->size,
-						'created_at' => isset( $media->created_at->date ) ? $media->created_at->date : $media->created_at,
-						'updated_at' => isset( $media->updated_at->date ) ? $media->updated_at->date : $media->updated_at,
+						'created_at' => isset($media->created_at) ? $media->created_at : $media->created_at,
+						'updated_at' => isset($media->updated_at) ? $media->updated_at : $media->updated_at,
 					)
 				);
 			}
 		}
 
-		if ( $featured_img_id ) {
-			set_post_thumbnail( $post_id, $featured_img_id );
+		if ($featured_img_id) {
+			set_post_thumbnail($post_id, $featured_img_id);
 		}
 
-		if ( ! empty( $gallery_ids ) ) {
+		if (!empty($gallery_ids)) {
 
-			$shortcode = '[gallery link="file" size="full" ids="' . implode( ',', $gallery_ids ) . '"]';
-			$shortcode = apply_filters( 'gc_content_gallery_shortcode', $shortcode, $gallery_ids, $post_data );
+			$shortcode = '[gallery link="file" size="full" ids="' . implode(',', $gallery_ids) . '"]';
+			$shortcode = apply_filters('gc_content_gallery_shortcode', $shortcode, $gallery_ids, $post_data);
 
-			$replacements['post_content'][ $gallery_token ] = $shortcode;
+			$replacements['post_content'][$gallery_token] = $shortcode;
 		}
 
-		return apply_filters( 'gc_media_replacements', $replacements, $attachments, $post_data );
+		return apply_filters('gc_media_replacements', $replacements, $attachments, $post_data);
 	}
 
 	/**
@@ -855,28 +883,29 @@ class Pull extends Base {
 	 *
 	 * @return int             The sideloaded attachment ID.
 	 */
-	protected function maybe_sideload_file( $media, $post_id ) {
-		$attachment = \GatherContent\Importer\get_post_by_item_id( $media->id, array( 'post_status' => 'inherit' ) );
+	protected function maybe_sideload_file($media, $post_id)
+	{
+		$attachment = \GatherContent\Importer\get_post_by_item_id($media->id, array('post_status' => 'inherit'));
 
-		if ( ! $attachment ) {
-			return $this->sideload_file( $media->id, $media->filename, $post_id );
+		if (!$attachment) {
+			return $this->sideload_file($media->id, $media->filename, $post_id);
 		}
 
 		$attach_id = $attachment->ID;
 
-		if ( $meta = \GatherContent\Importer\get_post_item_meta( $attach_id ) ) {
+		if ($meta = \GatherContent\Importer\get_post_item_meta($attach_id)) {
 
 			$meta        = (object) $meta;
-			$new_updated = strtotime( isset( $media->updated_at->date ) ? $media->updated_at->date : $media->updated_at );
-			$old_updated = strtotime( $meta->updated_at );
+			$new_updated = strtotime(isset($media->updated_at) ? $media->updated_at : $media->updated_at);
+			$old_updated = strtotime($meta->updated_at);
 
 			// Check if updated time-stamp is newer than previous updated timestamp.
-			if ( $new_updated > $old_updated ) {
+			if ($new_updated > $old_updated) {
 
-				$replace_data = apply_filters( 'gc_replace_attachment_data_on_update', false, $attachment );
+				$replace_data = apply_filters('gc_replace_attachment_data_on_update', false, $attachment);
 
 				// @todo How to handle failures?
-				$attach_id = $this->sideload_and_update_attachment( $media->id, $media->filename, $attachment, $replace_data );
+				$attach_id = $this->sideload_and_update_attachment($media->id, $media->filename, $attachment, $replace_data);
 			}
 		}
 
@@ -891,30 +920,31 @@ class Pull extends Base {
 	 * @param int    $post_id   The post ID the media is to be associated with.
 	 * @return string|WP_Error  Populated HTML img tag on success, WP_Error object otherwise.
 	 */
-	protected function sideload_file( $file_url, $file_name, $post_id ) {
-		if ( ! empty( $file_url ) ) {
-			$file_array = $this->tmp_file( $file_url, $file_name );
+	protected function sideload_file($file_url, $file_name, $post_id)
+	{
+		if (!empty($file_url)) {
+			$file_array = $this->tmp_file($file_url, $file_name);
 
-			if ( is_wp_error( $file_array ) ) {
+			if (is_wp_error($file_array)) {
 				return $file_array;
 			}
 
 			// Do the validation and storage stuff.
-			$id = media_handle_sideload( $file_array, $post_id );
+			$id = media_handle_sideload($file_array, $post_id);
 
 			// If error storing permanently, unlink.
-			if ( is_wp_error( $id ) ) {
+			if (is_wp_error($id)) {
 				// @codingStandardsIgnoreStart
-				@unlink( $file_array['tmp_name'] );
+				@unlink($file_array['tmp_name']);
 				// @codingStandardsIgnoreEnd
 				return $id;
 			}
 
-			$src = wp_get_attachment_url( $id );
+			$src = wp_get_attachment_url($id);
 		}
 
 		// Finally, check to make sure the file has been saved, then return the ID.
-		return ! empty( $src ) ? $id : new WP_Error( 'image_sideload_failed' );
+		return !empty($src) ? $id : new WP_Error('image_sideload_failed');
 	}
 
 	/**
@@ -930,26 +960,27 @@ class Pull extends Base {
 	 *
 	 * @return int                  The sideloaded attachment ID.
 	 */
-	protected function sideload_and_update_attachment( $file_url, $file_name, $attachment, $replace_data = false ) {
-		if ( ! isset( $attachment->ID ) || empty( $file_url ) ) {
-			return new WP_Error( 'sideload_and_update_attachment_error' );
+	protected function sideload_and_update_attachment($file_url, $file_name, $attachment, $replace_data = false)
+	{
+		if (!isset($attachment->ID) || empty($file_url)) {
+			return new WP_Error('sideload_and_update_attachment_error');
 		}
 
 		// @codingStandardsIgnoreStart
 		// 5 minutes per image should be PLENTY.
-		@set_time_limit( 900 );
+		@set_time_limit(900);
 		// @codingStandardsIgnoreEnd
 
-		$time = substr( $attachment->post_date, 0, 4 ) > 0
+		$time = substr($attachment->post_date, 0, 4) > 0
 			? $attachment->post_date
-			: current_time( 'mysql' );
+			: current_time('mysql');
 
-		$file_array = $this->tmp_file( $file_url, $file_name );
+		$file_array = $this->tmp_file($file_url, $file_name);
 
-		$file = wp_handle_sideload( $file_array, array( 'test_form' => false ), $time );
+		$file = wp_handle_sideload($file_array, array('test_form' => false), $time);
 
-		if ( isset( $file['error'] ) ) {
-			return new WP_Error( 'upload_error', $file['error'] );
+		if (isset($file['error'])) {
+			return new WP_Error('upload_error', $file['error']);
 		}
 
 		$args                   = (array) $attachment;
@@ -957,18 +988,18 @@ class Pull extends Base {
 
 		$_file = $file['file'];
 
-		if ( $replace_data ) {
-			$title   = preg_replace( '/\.[^.]+$/', '', basename( $_file ) );
+		if ($replace_data) {
+			$title   = preg_replace('/\.[^.]+$/', '', basename($_file));
 			$content = '';
 
 			// Use image exif/iptc data for title and caption defaults if possible.
 			// @codingStandardsIgnoreStart
-			if ( $image_meta = @wp_read_image_metadata( $_file ) ) {
+			if ($image_meta = @wp_read_image_metadata($_file)) {
 				// @codingStandardsIgnoreEnd
-				if ( trim( $image_meta['title'] ) && ! is_numeric( sanitize_title( $image_meta['title'] ) ) ) {
+				if (trim($image_meta['title']) && !is_numeric(sanitize_title($image_meta['title']))) {
 					$title = $image_meta['title'];
 				}
-				if ( trim( $image_meta['caption'] ) ) {
+				if (trim($image_meta['caption'])) {
 					$content = $image_meta['caption'];
 				}
 			}
@@ -978,15 +1009,15 @@ class Pull extends Base {
 		}
 
 		// Save the attachment metadata.
-		$id = wp_insert_attachment( $args, $_file, $attachment->post_parent );
+		$id = wp_insert_attachment($args, $_file, $attachment->post_parent);
 
-		if ( is_wp_error( $id ) ) {
+		if (is_wp_error($id)) {
 			// If error storing permanently, unlink.
 			// @codingStandardsIgnoreStart
-			@unlink( $file_array['tmp_name'] );
+			@unlink($file_array['tmp_name']);
 			// @codingStandardsIgnoreEnd
 		} else {
-			wp_update_attachment_metadata( $id, wp_generate_attachment_metadata( $id, $_file ) );
+			wp_update_attachment_metadata($id, wp_generate_attachment_metadata($id, $_file));
 		}
 
 		return $id;
@@ -1002,7 +1033,8 @@ class Pull extends Base {
 	 *
 	 * @return array              The temporary file array.
 	 */
-	protected function tmp_file( $file_id, $file_name ) {
+	protected function tmp_file($file_id, $file_name)
+	{
 		require_once ABSPATH . '/wp-admin/includes/file.php';
 		require_once ABSPATH . '/wp-admin/includes/media.php';
 		require_once ABSPATH . '/wp-admin/includes/image.php';
@@ -1010,16 +1042,16 @@ class Pull extends Base {
 		$file_array = array();
 
 		// Download file to temp location.
-		$file_array['tmp_name'] = $this->api->get_file( $file_id );
+		$file_array['tmp_name'] = $this->api->get_file($file_id);
 
 		// If error storing temporarily, return the error.
-		if ( is_wp_error( $file_array['tmp_name'] ) ) {
+		if (is_wp_error($file_array['tmp_name'])) {
 			return $file_array['tmp_name'];
 		}
 
-		preg_match( '/[^\?]+\.(jpe?g|jpe|gif|png)\b/i', $file_name, $matches );
+		preg_match('/[^\?]+\.(jpe?g|jpe|gif|png)\b/i', $file_name, $matches);
 
-		$file_array['name'] = $matches ? basename( $matches[0] ) : basename( $file_name );
+		$file_array['name'] = $matches ? basename($matches[0]) : basename($file_name);
 
 		return $file_array;
 	}
@@ -1033,8 +1065,9 @@ class Pull extends Base {
 	 *
 	 * @return bool
 	 */
-	public static function attachment_is_image( $attach_id ) {
-		return preg_match( '~(jpe?g|jpe|gif|png|svg)\b~', get_post_mime_type( $attach_id ) );
+	public static function attachment_is_image($attach_id)
+	{
+		return preg_match('~(jpe?g|jpe|gif|png|svg)\b~', get_post_mime_type($attach_id));
 	}
 
 	/**
@@ -1046,11 +1079,12 @@ class Pull extends Base {
 	 *
 	 * @return int|WP_Error The value 0 or WP_Error on failure. The post ID on success.
 	 */
-	protected static function post_update_no_revision( $post_data ) {
+	protected static function post_update_no_revision($post_data)
+	{
 		// Update post (but don't create a revision for it).
-		remove_action( 'post_updated', 'wp_save_post_revision' );
-		$post_id = wp_update_post( $post_data );
-		add_action( 'post_updated', 'wp_save_post_revision' );
+		remove_action('post_updated', 'wp_save_post_revision');
+		$post_id = wp_update_post($post_data);
+		add_action('post_updated', 'wp_save_post_revision');
 
 		return $post_id;
 	}
@@ -1066,8 +1100,9 @@ class Pull extends Base {
 	 *
 	 * @return bool              Whether post type supports hierarchy.
 	 */
-	public function should_map_hierarchy( $post_type ) {
-		return apply_filters( 'gc_map_hierarchy', is_post_type_hierarchical( $post_type ), $post_type, $this );
+	public function should_map_hierarchy($post_type)
+	{
+		return apply_filters('gc_map_hierarchy', is_post_type_hierarchical($post_type), $post_type, $this);
 	}
 
 	/**
@@ -1079,33 +1114,34 @@ class Pull extends Base {
 	 *
 	 * @return void
 	 */
-	public function schedule_hierarchy_update( $post_id ) {
+	public function schedule_hierarchy_update($post_id)
+	{
 
 		$option = "gc_associate_hierarchy_{$this->mapping->ID}";
 
 		// Check we have existing pending hierchies to set.
-		$pending = get_option( "gc_associate_hierarchy_{$this->mapping->ID}", array() );
-		if ( empty( $pending ) || ! is_array( $pending ) ) {
-			$pending = array( $post_id => $this->item->parent_id );
+		$pending = get_option("gc_associate_hierarchy_{$this->mapping->ID}", array());
+		if (empty($pending) || !is_array($pending)) {
+			$pending = array($post_id => $this->item->parent_id);
 		} else {
-			$pending[ $post_id ] = $this->item->parent_id;
+			$pending[$post_id] = $this->item->parent_id;
 		}
 
 		// Update list of pending hierarchies for this mapping.
-		update_option( "gc_associate_hierarchy_{$this->mapping->ID}", $pending, false );
+		update_option("gc_associate_hierarchy_{$this->mapping->ID}", $pending, false);
 
-		$args = array( $this->mapping->ID );
+		$args = array($this->mapping->ID);
 
 		// We'll want to restart our 'timer'.
-		if ( wp_next_scheduled( 'gc_associate_hierarchy', $args ) ) {
-			wp_clear_scheduled_hook( 'gc_associate_hierarchy', $args );
+		if (wp_next_scheduled('gc_associate_hierarchy', $args)) {
+			wp_clear_scheduled_hook('gc_associate_hierarchy', $args);
 		}
 
 		/*
 		 * Schedule an event to associate hierarchy for these posts.
 		 * Will likely never be hit, as the gc_pull_complete event will take precedence.
 		 */
-		wp_schedule_single_event( time() + 60, 'gc_associate_hierarchy', $args );
+		wp_schedule_single_event(time() + 60, 'gc_associate_hierarchy', $args);
 	}
 
 	/**
@@ -1118,22 +1154,23 @@ class Pull extends Base {
 	 *
 	 * @return void
 	 */
-	public static function associate_hierarchy( $mapping ) {
-		$mapping = Mapping_Post::get( $mapping, true );
-		if ( ! $mapping ) {
+	public static function associate_hierarchy($mapping)
+	{
+		$mapping = Mapping_Post::get($mapping, true);
+		if (!$mapping) {
 			return;
 		}
 
 		$mapping_id = $mapping->ID;
 
 		$opt_name = "gc_associate_hierarchy_{$mapping_id}";
-		$pending  = get_option( $opt_name, array() );
+		$pending  = get_option($opt_name, array());
 
-		if ( ! empty( $pending ) && is_array( $pending ) ) {
-			foreach ( $pending as $post_id => $parent_item_id ) {
-				$post = get_post( absint( $post_id ) );
+		if (!empty($pending) && is_array($pending)) {
+			foreach ($pending as $post_id => $parent_item_id) {
+				$post = get_post(absint($post_id));
 
-				if ( ! $post ) {
+				if (!$post) {
 					continue;
 				}
 
@@ -1144,7 +1181,7 @@ class Pull extends Base {
 					)
 				);
 
-				if ( ! $parent_post || ! isset( $parent_post->ID ) ) {
+				if (!$parent_post || !isset($parent_post->ID)) {
 					continue;
 				}
 
@@ -1152,18 +1189,17 @@ class Pull extends Base {
 				$post_id = self::post_update_no_revision(
 					array(
 						'ID'          => $post->ID,
-						'post_parent' => absint( $parent_post->ID ),
+						'post_parent' => absint($parent_post->ID),
 					)
 				);
 			}
 		}
 
 		// We'll want to clear any scheduled events, since we completed them.
-		if ( wp_next_scheduled( 'gc_associate_hierarchy', array( $mapping_id ) ) ) {
-			wp_clear_scheduled_hook( 'gc_associate_hierarchy', array( $mapping_id ) );
+		if (wp_next_scheduled('gc_associate_hierarchy', array($mapping_id))) {
+			wp_clear_scheduled_hook('gc_associate_hierarchy', array($mapping_id));
 		}
 
-		return delete_option( $opt_name );
+		return delete_option($opt_name);
 	}
-
 }

--- a/includes/classes/sync/pull.php
+++ b/includes/classes/sync/pull.php
@@ -212,25 +212,6 @@ class Pull extends Base {
 			}
 		}
 
-		/*
-		// Check if we need to set hierarchies.
-		if ( $this->should_map_hierarchy( $post_data['post_type'] ) && isset( $this->item->parent_id ) && $this->item->parent_id ) {
-
-			// Check if an associated WordPress item exists for the parent item id.
-			$parent_post = \GatherContent\Importer\get_post_by_item_id( absint( $this->item->parent_id ), array(
-				'post_type' => $post_data['post_type'],
-			) );
-
-			// If so, we'll go ahead and update the post_parent value.
-			if ( $parent_post && isset( $parent_post->ID ) ) {
-				$updated_post_data['post_parent'] = absint( $parent_post->ID );
-			}
-			// Otherwise, let's save this to the array of IDs needed to be checked later (let the import finish).
-			else {
-				$this->schedule_hierarchy_update( $post_id );
-			}
-		}*/
-
 		if ( ! empty( $updated_post_data ) ) {
 			// And update post (but don't create a revision for it).
 			self::post_update_no_revision( array_merge( $post_data, $updated_post_data ) );
@@ -272,14 +253,9 @@ class Pull extends Base {
 			$post_data[ $key ] = 'gcinitial';
 		}
 
-		// $files = $this->api->uncached()->get_item_files($this->item->id);
+		$files = $this->api->uncached()->get_item_files( $this->item->id );
 
-		// $this->item->files = array();
-		// if (is_array($files)) {
-		// foreach ($files as $file) {
-		// $this->item->files[$file->field][] = $file;
-		// }
-		// }
+		$this->item->files = is_array( $files ) ? $files : array();
 
 		if ( $this->should_map_hierarchy( $post_data['post_type'] ) && isset( $this->item->position ) ) {
 			$post_data['menu_order'] = absint( $this->item->position );
@@ -514,7 +490,7 @@ class Pull extends Base {
 
 		$post_data['meta_input'] = $this->maybe_append( $meta_key, $value, $post_data['meta_input'] );
 
-		if ( 'files' === $this->element->type ) {
+		if ( 'attachment' === $this->element->type ) {
 			$post_data = $this->set_media_field_value( $meta_key, $post_data );
 		}
 

--- a/includes/classes/sync/push.php
+++ b/includes/classes/sync/push.php
@@ -250,8 +250,8 @@ class Push extends Base {
 			\GatherContent\Importer\update_post_item_meta(
 				$this->post->ID,
 				array(
-					'created_at' => $this->item->created_at->date,
-					'updated_at' => $this->item->updated_at->date,
+					'created_at' => $this->item->created_at,
+					'updated_at' => $this->item->updated_at,
 				)
 			);
 		}

--- a/includes/functions/functions.php
+++ b/includes/functions/functions.php
@@ -6,12 +6,13 @@
  */
 
 namespace GatherContent\Importer;
+
 use WP_Query;
 
 /**
  * Style enqueue helper w/ GC defaults.
  *
- * @since  3.0.0
+ * @since 3.0.0
  *
  * @param string           $handle   Name of the stylesheet. Should be unique.
  * @param string           $filename Path (w/o extension/suffix) to CSS file in /assets/css/.
@@ -30,7 +31,7 @@ function enqueue_style( $handle, $filename, $deps = array(), $ver = GATHERCONTEN
 /**
  * Script enqueue helper w/ GC defaults.
  *
- * @since  3.0.0
+ * @since 3.0.0
  *
  * @param string           $handle   Name of the script. Should be unique.
  * @param string           $filename Path (w/o extension/suffix) to JS file in /assets/js/.
@@ -49,25 +50,28 @@ function enqueue_script( $handle, $filename, $deps = array(), $ver = GATHERCONTE
 /**
  * Wrapper for WP_Query that gets the assocated post for a GatherContent Item Id.
  *
- * @since  3.0.0
+ * @since 3.0.0
  *
- * @param  int   $item_id GatherContent Item Id.
- * @param  array $args    Optional array of WP_Query args.
+ * @param int   $item_id GatherContent Item Id.
+ * @param array $args    Optional array of WP_Query args.
  *
  * @return mixed          WP_Post if an associated post is found.
  */
 function get_post_by_item_id( $item_id, $args = array() ) {
-	global $wpml_query_filter;
+	 global $wpml_query_filter;
 	if ( is_object( $wpml_query_filter ) ) {
 		// We do not want wpml messing with our queries here.
 		remove_filter( 'posts_join', array( $wpml_query_filter, 'posts_join_filter' ), 10, 2 );
 		remove_filter( 'posts_where', array( $wpml_query_filter, 'posts_where_filter' ), 10, 2 );
 	}
 
-	$query = new WP_Query( wp_parse_args( $args, array(
-		'post_type'      => \GatherContent\Importer\available_mapping_post_types(),
-		'posts_per_page' => 1,
-		'no_found_rows'  => true,
+	$query = new WP_Query(
+		wp_parse_args(
+			$args,
+			array(
+				'post_type'      => \GatherContent\Importer\available_mapping_post_types(),
+				'posts_per_page' => 1,
+				'no_found_rows'  => true,
 		// @codingStandardsIgnoreStart
 		'meta_query'     => array(
 			array(
@@ -76,7 +80,9 @@ function get_post_by_item_id( $item_id, $args = array() ) {
 			),
 		),
 		// @codingStandardsIgnoreEnd
-	) ) );
+			)
+		)
+	);
 
 	return $query->have_posts() && $query->post ? $query->post : false;
 }
@@ -84,23 +90,23 @@ function get_post_by_item_id( $item_id, $args = array() ) {
 /**
  * Wrapper for get_post_meta that gets the associated GatherContent item ID, if it exists.
  *
- * @since  3.0.0
+ * @since 3.0.0
  *
- * @param  int $post_id The ID of the post to check.
+ * @param int $post_id The ID of the post to check.
  *
  * @return mixed         Result of get_post_meta.
  */
 function get_post_item_id( $post_id ) {
-	return get_post_meta( $post_id, '_gc_mapped_item_id', 1 );
+	 return get_post_meta( $post_id, '_gc_mapped_item_id', 1 );
 }
 
 /**
  * Wrapper for update_post_meta that saves the associated GatherContent item ID to the post's meta.
  *
- * @since  3.0.0
+ * @since 3.0.0
  *
- * @param  int $post_id The ID of the post to store the item ID against.
- * @param  int $item_id The item id to store against the post.
+ * @param int $post_id The ID of the post to store the item ID against.
+ * @param int $item_id The item id to store against the post.
  *
  * @return mixed         Result of update_post_meta.
  */
@@ -111,9 +117,9 @@ function update_post_item_id( $post_id, $item_id ) {
 /**
  * Wrapper for get_post_meta that gets the associated GatherContent item meta, if it exists.
  *
- * @since  3.0.0
+ * @since 3.0.0
  *
- * @param  int $post_id The ID of the post to check.
+ * @param int $post_id The ID of the post to check.
  *
  * @return mixed         Result of get_post_meta.
  */
@@ -125,23 +131,23 @@ function get_post_item_meta( $post_id ) {
 /**
  * Wrapper for update_post_meta that saves the associated GatherContent item meta to the post's meta.
  *
- * @since  3.0.0
+ * @since 3.0.0
  *
- * @param  int   $post_id The ID of the post to update.
- * @param  mixed $meta    The item meta to store against the post.
+ * @param int   $post_id The ID of the post to update.
+ * @param mixed $meta    The item meta to store against the post.
  *
  * @return mixed          Result of update_post_meta.
  */
 function update_post_item_meta( $post_id, $meta ) {
-	return update_post_meta( $post_id, '_gc_mapped_meta', $meta );
+	 return update_post_meta( $post_id, '_gc_mapped_meta', $meta );
 }
 
 /**
  * Wrapper for get_post_meta that gets the associated GatherContent mapping post ID, if it exists.
  *
- * @since  3.0.0
+ * @since 3.0.0
  *
- * @param  int $post_id The ID of the post to check.
+ * @param int $post_id The ID of the post to check.
  *
  * @return mixed Result of get_post_meta.
  */
@@ -152,31 +158,31 @@ function get_post_mapping_id( $post_id ) {
 /**
  * Wrapper for update_post_meta that saves the associated GatherContent mapping post ID to the post's meta.
  *
- * @since  3.0.0
+ * @since 3.0.0
  *
- * @param  int $post_id The ID of the post to update.
- * @param  int $mapping_post_id The ID of the mapping post.
+ * @param int $post_id         The ID of the post to update.
+ * @param int $mapping_post_id The ID of the mapping post.
  *
  * @return mixed Result of update_post_meta.
  */
 function update_post_mapping_id( $post_id, $mapping_post_id ) {
-	return update_post_meta( $post_id, '_gc_mapping_id', $mapping_post_id );
+	 return update_post_meta( $post_id, '_gc_mapping_id', $mapping_post_id );
 }
 
 /**
  * Augment a GatherContent item object with additional data for JS templating.
  *
- * @since  3.0.0
+ * @since 3.0.0
  *
- * @param  object $item       GatherContent item object.
- * @param  int    $mapping_id Optional. ID of the mapping post.
+ * @param object $item       GatherContent item object.
+ * @param int    $mapping_id Optional. ID of the mapping post.
  *
  * @return array              Object prepared for JS.
  */
 function prepare_item_for_js( $item, $mapping_id = 0 ) {
 	$post = \GatherContent\Importer\get_post_by_item_id( $item->id );
 
-	$js_item = (array) $item;
+	$js_item            = (array) $item;
 	$js_item['mapping'] = $mapping_id;
 
 	if ( $post ) {
@@ -197,10 +203,10 @@ function prepare_item_for_js( $item, $mapping_id = 0 ) {
 /**
  * Get a an array of data from a WP_Post object to be used as a backbone model.
  *
- * @since  3.0.0
+ * @since 3.0.0
  *
- * @param  mixed $post     WP_Post or post ID.
- * @param  bool  $uncached Whether to fetch item data uncached. Default is to ONLY fetch from cache.
+ * @param mixed $post     WP_Post or post ID.
+ * @param bool  $uncached Whether to fetch item data uncached. Default is to ONLY fetch from cache.
  *
  * @return array           JS post array.
  */
@@ -229,8 +235,8 @@ function prepare_post_for_js( $post, $uncached = false ) {
 	$item = null;
 	if ( $js_post['item'] ) {
 		$item = $uncached
-			? General::get_instance()->api->uncached()->get_item( $js_post['item'] )
-			: General::get_instance()->api->only_cached()->get_item( $js_post['item'] );
+		? General::get_instance()->api->uncached()->get_item( $js_post['item'] )
+		: General::get_instance()->api->only_cached()->get_item( $js_post['item'] );
 	}
 
 	return \GatherContent\Importer\prepare_js_data( $js_post, $item );
@@ -239,33 +245,36 @@ function prepare_post_for_js( $post, $uncached = false ) {
 /**
  * Get a an array of data from a WP_Post or GC item object to be used as a backbone model.
  *
- * @since  3.0.0
+ * @since 3.0.0
  *
- * @param  array  $args Array of args to be added to.
- * @param  object $item GatherContent item object.
- * @param  string $type Which type of data we are preparing, 'post' or 'item'.
+ * @param array  $args Array of args to be added to.
+ * @param object $item GatherContent item object.
+ * @param string $type Which type of data we are preparing, 'post' or 'item'.
  *
  * @return array        Array of modified args.
  */
 function prepare_js_data( $args, $item = null, $type = 'post' ) {
-	$args = wp_parse_args( $args, array(
-		'item'        => 0,
-		'itemName'    => __( 'N/A', 'gathercontent-importer' ),
-		'mapping'     => 0,
-		'post_id'     => 0,
-		'mappingLink' => '',
-		'mappingName' => __( '&mdash;', 'gathercontent-importer' ),
-		'status'      => (object) array(),
-		'itemName'    => __( 'N/A', 'gathercontent-importer' ),
-		'updated_at'  => __( '&mdash;', 'gathercontent-importer' ),
-		'editLink'    => '',
-		'post_title'  => __( '&mdash;', 'gathercontent-importer' ),
-		'ptLabel'     => __( 'Post', 'gathercontent-importer' ),
-	) );
+	$args = wp_parse_args(
+		$args,
+		array(
+			'item'        => 0,
+			'itemName'    => __( 'N/A', 'gathercontent-importer' ),
+			'mapping'     => 0,
+			'post_id'     => 0,
+			'mappingLink' => '',
+			'mappingName' => __( '&mdash;', 'gathercontent-importer' ),
+			'status'      => (object) array(),
+			'itemName'    => __( 'N/A', 'gathercontent-importer' ),
+			'updated_at'  => __( '&mdash;', 'gathercontent-importer' ),
+			'editLink'    => '',
+			'post_title'  => __( '&mdash;', 'gathercontent-importer' ),
+			'ptLabel'     => __( 'Post', 'gathercontent-importer' ),
+		)
+	);
 
 	if ( $mapping = Mapping_Post::get( $args['mapping'] ) ) {
 		$args['mappingLink'] = get_edit_post_link( $mapping->ID );
-		$account = $mapping->get_account_slug();
+		$account             = $mapping->get_account_slug();
 		$args['mappingName'] = $mapping->post_title . ( $account ? " ($account)" : '' );
 	}
 
@@ -276,12 +285,12 @@ function prepare_js_data( $args, $item = null, $type = 'post' ) {
 		}
 
 		$args['status'] = isset( $item->status->data )
-			? $item->status->data
-			: (object) array();
+		? $item->status->data
+		: (object) array();
 
 		$args['typeName'] = isset( $item->type )
-			? Utils::gc_field_type_name( $item->type )
-			: '';
+		? Utils::gc_field_type_name( $item->type )
+		: '';
 
 		if ( isset( $item->updated_at ) ) {
 			$args['updated_at'] = Utils::relative_date( $item->updated_at );
@@ -302,9 +311,9 @@ function prepare_js_data( $args, $item = null, $type = 'post' ) {
 /**
  * Gets the singular label for a post's post-type object.
  *
- * @since  3.0.0
+ * @since 3.0.0
  *
- * @param  mixed  $post WP_Post
+ * @param mixed $post WP_Post
  *
  * @return string       Singular post-type label.
  */
@@ -316,17 +325,17 @@ function get_post_type_singular_label( $post ) {
 	$object = get_post_type_object( $post->post_type );
 
 	return isset( $object->labels->singular_name )
-		? $object->labels->singular_name
-		: $object->labels->name;
+	? $object->labels->singular_name
+	: $object->labels->name;
 }
 
 /**
  * Checks to see if a post is current with a GatherContent item.
  *
- * @since  3.0.0
+ * @since 3.0.0
  *
- * @param  int   $post_id Post ID.
- * @param  mixed $item    GatherContent item object.
+ * @param int   $post_id Post ID.
+ * @param mixed $item    GatherContent item object.
  *
  * @return bool           Whether post is current.
  */
@@ -353,18 +362,23 @@ function post_is_current( $post_id, $item ) {
 /**
  * A button for flushing the cached connection to GC's API.
  *
- * @since  3.0.0
+ * @since 3.0.0
  *
  * @return string URL for flushing cache.
  */
 function refresh_connection_link() {
 	$args = array(
 		'redirect_url' => false,
-		'flush_url' => add_query_arg( array( 'flush_cache' => 1, 'redirect' => 1 ) ),
+		'flush_url'    => add_query_arg(
+			array(
+				'flush_cache' => 1,
+				'redirect'    => 1,
+			)
+		),
 	);
 	// @codingStandardsIgnoreStart
 	if ( isset( $_GET['flush_cache'], $_GET['redirect'] ) ) {
-		// @codingStandardsIgnoreEnd
+	// @codingStandardsIgnoreEnd
 		update_option( 'gc-api-updated', 1, false );
 		$args['redirect_url'] = remove_query_arg( 'flush_cache', remove_query_arg( 'redirect' ) );
 	}
@@ -377,7 +391,7 @@ function refresh_connection_link() {
 /**
  * Determine if current user can view GC settings.
  *
- * @since  3.0.0
+ * @since 3.0.0
  *
  * @return bool Whether current user can view GC settings.
  */
@@ -388,7 +402,7 @@ function user_allowed() {
 /**
  * Capability for user to be able to view GC settings.
  *
- * @since  3.0.0
+ * @since 3.0.0
  *
  * @return string Capability
  */
@@ -400,7 +414,7 @@ function view_capability() {
  * The filtered list of post-types available for mapping to GC items.
  * Modify with the 'gathercontent_mapping_post_types' filter.
  *
- * @since  3.0.3
+ * @since 3.0.3
  *
  * @return array  Array of post-type slugs.
  */
@@ -412,12 +426,12 @@ function available_mapping_post_types() {
 /**
  * Detect if HTTP Auth is enabled.
  *
- * @since  3.0.7
+ * @since 3.0.7
  *
  * @return string|bool The Auth username if enabled, or false.
  */
 function auth_enabled() {
-	if ( !empty( $_SERVER['REMOTE_USER'] ) ) {
+	if ( ! empty( $_SERVER['REMOTE_USER'] ) ) {
 		return $_SERVER['REMOTE_USER'];
 	}
 
@@ -426,7 +440,7 @@ function auth_enabled() {
 		'PHP_AUTH_PW',
 		'HTTP_AUTHORIZATION',
 	) as $var ) {
-		if ( !empty( $_SERVER[ $var ] ) ) {
+		if ( ! empty( $_SERVER[ $var ] ) ) {
 			return true;
 		}
 	}

--- a/includes/functions/functions.php
+++ b/includes/functions/functions.php
@@ -6,7 +6,6 @@
  */
 
 namespace GatherContent\Importer;
-
 use WP_Query;
 
 /**
@@ -65,13 +64,10 @@ function get_post_by_item_id( $item_id, $args = array() ) {
 		remove_filter( 'posts_where', array( $wpml_query_filter, 'posts_where_filter' ), 10, 2 );
 	}
 
-	$query = new WP_Query(
-		wp_parse_args(
-			$args,
-			array(
-				'post_type'      => \GatherContent\Importer\available_mapping_post_types(),
-				'posts_per_page' => 1,
-				'no_found_rows'  => true,
+	$query = new WP_Query( wp_parse_args( $args, array(
+		'post_type'      => \GatherContent\Importer\available_mapping_post_types(),
+		'posts_per_page' => 1,
+		'no_found_rows'  => true,
 		// @codingStandardsIgnoreStart
 		'meta_query'     => array(
 			array(
@@ -80,9 +76,7 @@ function get_post_by_item_id( $item_id, $args = array() ) {
 			),
 		),
 		// @codingStandardsIgnoreEnd
-			)
-		)
-	);
+	) ) );
 
 	return $query->have_posts() && $query->post ? $query->post : false;
 }
@@ -182,7 +176,7 @@ function update_post_mapping_id( $post_id, $mapping_post_id ) {
 function prepare_item_for_js( $item, $mapping_id = 0 ) {
 	$post = \GatherContent\Importer\get_post_by_item_id( $item->id );
 
-	$js_item            = (array) $item;
+	$js_item = (array) $item;
 	$js_item['mapping'] = $mapping_id;
 
 	if ( $post ) {
@@ -254,27 +248,24 @@ function prepare_post_for_js( $post, $uncached = false ) {
  * @return array        Array of modified args.
  */
 function prepare_js_data( $args, $item = null, $type = 'post' ) {
-	$args = wp_parse_args(
-		$args,
-		array(
-			'item'        => 0,
-			'itemName'    => __( 'N/A', 'gathercontent-importer' ),
-			'mapping'     => 0,
-			'post_id'     => 0,
-			'mappingLink' => '',
-			'mappingName' => __( '&mdash;', 'gathercontent-importer' ),
-			'status'      => (object) array(),
-			'itemName'    => __( 'N/A', 'gathercontent-importer' ),
-			'updated_at'  => __( '&mdash;', 'gathercontent-importer' ),
-			'editLink'    => '',
-			'post_title'  => __( '&mdash;', 'gathercontent-importer' ),
-			'ptLabel'     => __( 'Post', 'gathercontent-importer' ),
-		)
-	);
+	$args = wp_parse_args( $args, array(
+		'item'        => 0,
+		'itemName'    => __( 'N/A', 'gathercontent-importer' ),
+		'mapping'     => 0,
+		'post_id'     => 0,
+		'mappingLink' => '',
+		'mappingName' => __( '&mdash;', 'gathercontent-importer' ),
+		'status'      => (object) array(),
+		'itemName'    => __( 'N/A', 'gathercontent-importer' ),
+		'updated_at'  => __( '&mdash;', 'gathercontent-importer' ),
+		'editLink'    => '',
+		'post_title'  => __( '&mdash;', 'gathercontent-importer' ),
+		'ptLabel'     => __( 'Post', 'gathercontent-importer' ),
+	) );
 
 	if ( $mapping = Mapping_Post::get( $args['mapping'] ) ) {
 		$args['mappingLink'] = get_edit_post_link( $mapping->ID );
-		$account             = $mapping->get_account_slug();
+		$account = $mapping->get_account_slug();
 		$args['mappingName'] = $mapping->post_title . ( $account ? " ($account)" : '' );
 	}
 
@@ -283,21 +274,17 @@ function prepare_js_data( $args, $item = null, $type = 'post' ) {
 		if ( isset( $item->name ) ) {
 			$args['itemName'] = $item->name;
 		}
-		if ( @$item->status->data ) :
-			$args['status'] = isset( $item->status->data )
+
+		$args['status'] = isset( $item->status->data )
 			? $item->status->data
 			: (object) array();
-		elseif ( @$item->status ) :
-			$args['status'] = isset( $item->status )
-			? $item->status
-			: (object) array();
-		endif;
+
 		$args['typeName'] = isset( $item->type )
 			? Utils::gc_field_type_name( $item->type )
 			: '';
 
-		if ( isset( $item->updated_at->date ) ) {
-			$args['updated_at'] = Utils::relative_date( $item->updated_at->date );
+		if ( isset( $item->updated_at ) ) {
+			$args['updated_at'] = Utils::relative_date( $item->updated_at );
 		}
 	}
 
@@ -317,7 +304,7 @@ function prepare_js_data( $args, $item = null, $type = 'post' ) {
  *
  * @since  3.0.0
  *
- * @param  mixed $post WP_Post
+ * @param  mixed  $post WP_Post
  *
  * @return string       Singular post-type label.
  */
@@ -350,14 +337,10 @@ function post_is_current( $post_id, $item ) {
 
 	if ( ! empty( $meta['updated_at'] ) ) {
 
-		if ( isset( $item->updated_at->date ) ) {
-
-			if ( is_object( $meta['updated_at'] ) ) {
-				$meta['updated_at'] = $meta['updated_at']->date;
-			}
+		if ( isset( $item->updated_at ) ) {
 
 			// Allowance of 10 milliseconds because of some possible race conditions.
-			$is_current = Utils::date_current_with( $meta['updated_at'], $item->updated_at->date, 10 );
+			$is_current = Utils::date_current_with( $meta['updated_at'], $item->updated_at, 10 );
 		} else {
 			// If we couldn't find an item date, then we'll say, yes, we're current.
 			$is_current = true;
@@ -377,12 +360,7 @@ function post_is_current( $post_id, $item ) {
 function refresh_connection_link() {
 	$args = array(
 		'redirect_url' => false,
-		'flush_url'    => add_query_arg(
-			array(
-				'flush_cache' => 1,
-				'redirect'    => 1,
-			)
-		),
+		'flush_url' => add_query_arg( array( 'flush_cache' => 1, 'redirect' => 1 ) ),
 	);
 	// @codingStandardsIgnoreStart
 	if ( isset( $_GET['flush_cache'], $_GET['redirect'] ) ) {
@@ -439,7 +417,7 @@ function available_mapping_post_types() {
  * @return string|bool The Auth username if enabled, or false.
  */
 function auth_enabled() {
-	if ( ! empty( $_SERVER['REMOTE_USER'] ) ) {
+	if ( !empty( $_SERVER['REMOTE_USER'] ) ) {
 		return $_SERVER['REMOTE_USER'];
 	}
 
@@ -448,7 +426,7 @@ function auth_enabled() {
 		'PHP_AUTH_PW',
 		'HTTP_AUTHORIZATION',
 	) as $var ) {
-		if ( ! empty( $_SERVER[ $var ] ) ) {
+		if ( !empty( $_SERVER[ $var ] ) ) {
 			return true;
 		}
 	}

--- a/includes/functions/functions.php
+++ b/includes/functions/functions.php
@@ -58,7 +58,7 @@ function enqueue_script( $handle, $filename, $deps = array(), $ver = GATHERCONTE
  * @return mixed          WP_Post if an associated post is found.
  */
 function get_post_by_item_id( $item_id, $args = array() ) {
-	 global $wpml_query_filter;
+	global $wpml_query_filter;
 	if ( is_object( $wpml_query_filter ) ) {
 		// We do not want wpml messing with our queries here.
 		remove_filter( 'posts_join', array( $wpml_query_filter, 'posts_join_filter' ), 10, 2 );

--- a/includes/views/underscore-data-status.php
+++ b/includes/views/underscore-data-status.php
@@ -1,2 +1,2 @@
 <span class="gc-status-color <# if ( '#ffffff' === data.status.color ) { #> gc-status-color-white<# } #>" style="background-color:{{ data.status.color ?? '#fff' }};" data-id="{{ data.status_id }}"></span>
-<span class="gc-status-name">{{ data.status_name ?? 'N/A' }}</span>
+<span class="gc-status-name">{{ data.status_name ? data.status_name : ( data.status.name ?? 'N/A' ) }}</span>

--- a/includes/views/underscore-data-status.php
+++ b/includes/views/underscore-data-status.php
@@ -1,2 +1,2 @@
-<span class="gc-status-color <# if ( '#ffffff' === data.status_color ) { #> gc-status-color-white<# } #>" style="background-color:{{ data.status_color ?? '#fff' }};" data-id="{{ data.status_id }}"></span>
+<span class="gc-status-color <# if ( '#ffffff' === data.status.color ) { #> gc-status-color-white<# } #>" style="background-color:{{ data.status.color ?? '#fff' }};" data-id="{{ data.status_id }}"></span>
 <span class="gc-status-name">{{ data.status_name ?? 'N/A' }}</span>


### PR DESCRIPTION
### Summary

This PR mainly includes the Single Item API code refactor to add V2 APIs support to the code.


### Details

This PR includes:

- Appending cached status data to the single_item request, because it was removed in the V2 APIs.
- Refactor the complete single item code to support V2 APIs syntax in the code and change wherever this method is being used Push/Pull.
- Add support for repeaters/components in the single item pull