### PR TITLE
Download File and Alt_text fixes

### DIFF
--- a/includes/classes/admin/mapping-wizard.php
+++ b/includes/classes/admin/mapping-wizard.php
@@ -516,7 +516,7 @@ class Mapping_Wizard extends Base {
 			)
 		);
 
-		if ( isset( $features['editor:new'] ) ) {
+		if ( isset( $features['editor:new'] ) && isset($template->data)) {
 			$structure_uuid = $template->data->structure_uuid;
 		}
 

--- a/includes/classes/api.php
+++ b/includes/classes/api.php
@@ -264,32 +264,6 @@ class API extends Base {
 	}
 
 	/**
-	 * GC API request to get download a file from "/files/<FILE_ID>/download" endpoint.
-	 *
-	 * @since  3.0.0
-	 *
-	 * @link https://docs.gathercontent.com/reference#get-filesfile_iddownload
-	 *
-	 * @param  int $file_id File ID.
-	 * @return mixed          Results of request.
-	 */
-	public function get_file( $file_id ) {
-		$tmpfname = wp_tempnam();
-		if ( ! $tmpfname ) {
-			return new WP_Error( 'http_no_file', __( 'Could not create Temporary file.' ) );
-		}
-
-		$response = $this->get(
-			'files/' . $file_id . '/download',
-			array(
-				'stream'   => true,
-				'filename' => $tmpfname,
-			)
-		);
-		return $tmpfname;
-	}
-
-	/**
 	 * GC V2 API request to get the results from the "/projects/{project_id}/templates" endpoint.
 	 *
 	 * @since  3.0.0

--- a/includes/classes/sync/base.php
+++ b/includes/classes/sync/base.php
@@ -408,8 +408,9 @@ abstract class Base extends Plugin_Base {
 				foreach ( $element_values as $value ) {
 					$file = array_values( wp_list_filter( $this->item->files, array( 'file_id' => $value->file_id ) ) );
 
-					if ( count( $file ) > 0 ) {
-						$file_values[] = $file[0];
+					if ( count( $file ) > 0 && isset( $file[0] ) && is_object( $file[0] ) ) {
+						$file[0]->alt_text = $value->alt_text;
+						$file_values[]     = $file[0];
 					}
 				}
 


### PR DESCRIPTION
This PR fixes a bug that was caused due to `500 SERVER_ERROR` in the download API which was resulting in corrupted images in media (happens occasionally), the error wasn't there till yesterday. (Screenshot below)

![image](https://user-images.githubusercontent.com/17910552/143427404-652bb5dd-76ee-4126-b9e1-486866597973.png)

so I rewrote the whole logic using `download_url()` method from `wp-admin/includes/file.php` to fix it.

Also includes some minor bug fixes for the `alt_text` support.